### PR TITLE
Get rid of warnings in dev mode

### DIFF
--- a/src/components/controls/buttons/Button.js
+++ b/src/components/controls/buttons/Button.js
@@ -169,7 +169,8 @@ const buttonTypes = [
   'success',
   'info',
   'warning',
-  'danger'
+  'danger',
+  'link'
 ];
 
 const buttonSizes = [

--- a/src/components/controls/buttons/Button.md
+++ b/src/components/controls/buttons/Button.md
@@ -118,14 +118,14 @@ const buttonContainerStyle = {
   width: '300px',
   height: '50px',
   padding: '10px',
-  ['background-color']: '#ddd',
+  backgroundColor: '#ddd',
   border: '1px solid #444'
 };
 
 function noop() { }
 
 <div style={buttonContainerStyle}>
-  <Button onClick={noop} block type="primary">Block button</Button>
+  <Button handleOnClick={noop} block type="primary">Block button</Button>
 </div>
 
 ```


### PR DESCRIPTION
There were some warnings being printed to the console during development. This gets rid of the ones in within our control.