### PR TITLE
Prettier with pre-commit hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,10 +8,19 @@
     "build": "babel src -d lib --ignore specs.js,*.md --copy-files",
     "ci": "npm run lint && npm test",
     "lint": "eslint src",
+    "precommit": "lint-staged",
     "prepublish": "npm run build",
+    "prettify": "prettier --single-quote --write \"src/**/*.js\"",
     "styleguide-build": "styleguidist build",
     "styleguide-server": "styleguidist server",
     "test": "jest"
+  },
+  "lint-staged": {
+    "*.js": [
+      "prettier --single-quote --write",
+      "eslint --fix",
+      "git add"
+    ]
   },
   "author": "Exchange Solutions",
   "license": "MIT",
@@ -40,10 +49,13 @@
     "eslint-plugin-babel": "^3.3.0",
     "eslint-plugin-react": "^4.3.0",
     "file-loader": "^0.9.0",
+    "husky": "^0.13.3",
     "jest": "^18.0.0",
     "less": "^2.7.1",
     "less-loader": "^2.2.3",
+    "lint-staged": "^3.4.1",
     "mockdate": "^2.0.1",
+    "prettier": "^1.3.1",
     "prop-types": "^15.5.6",
     "react": "^15.4.1",
     "react-addons-test-utils": "^15.4.1",


### PR DESCRIPTION
This adds the following new packages:
[prettier](https://github.com/prettier/prettier)
[lint-staged](https://github.com/okonet/lint-staged)
[husky](https://github.com/typicode/husky)

When you commit your files, it will prettify only the staged .js files and then run eslint --fix on them.  I haven't versioned this or prettified the whole project with this commit because I'm sure there will be opinions/feedback on this.  Maybe we don't want to auto fix lint issues, etc.

I also added a "prettify" npm script that will parse the whole project, mostly as reference, but also in case we decide to change any settings later it might be useful.