### PR TITLE
Updated Alert Component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "es-components",
-  "version": "3.5.3",
+  "version": "3.5.4",
   "description": "React components built for Exchange Solutions products",
   "repository": "https://github.com/TWExchangeSolutions/es-components",
   "main": "lib/index.js",

--- a/src/components/containers/alert/Alert.js
+++ b/src/components/containers/alert/Alert.js
@@ -42,6 +42,7 @@ const iconMap = {
 
 const AlertIcon = styled(Icon)`
   margin-right: 5px;
+  margin-bottom: 2px;
 `;
 
 function renderIcon(type) {
@@ -50,7 +51,12 @@ function renderIcon(type) {
 }
 
 const LeadingHeader = styled.p`
+  padding: 15px;
   margin: 0;
+`;
+
+const LeadingText = styled.span`
+  margin-left: ${props => (props.adjustText ? '22px' : '0')};
 `;
 
 function renderLeadingHeader(
@@ -61,13 +67,34 @@ function renderLeadingHeader(
 ) {
   const hasLeadingHeaderText = leadingHeader !== undefined;
   const hasLeadingText = leadingText !== undefined;
+  const adjustText = hasLeadingHeaderText && includeIcon;
 
   return (
     <LeadingHeader>
       {includeIcon ? renderIcon(alertType) : null}
       {hasLeadingHeaderText ? <strong>{leadingHeader}<br /></strong> : null}
-      {hasLeadingText ? leadingText : null}
+      <LeadingText adjustText={adjustText}>
+        {hasLeadingText ? leadingText : null}
+      </LeadingText>
     </LeadingHeader>
+  );
+}
+
+const ExtraNotification = styled.p`
+  padding: 15px;
+  margin: 0;
+`;
+
+const NotificationIcon = styled(Icon)`
+  margin-right: 10px;
+`;
+
+function renderExtraNotification(notificationText) {
+  return (
+    <ExtraNotification>
+      <NotificationIcon name="bell" />
+      <small>{notificationText}</small>
+    </ExtraNotification>
   );
 }
 
@@ -107,7 +134,7 @@ function renderCallsToAction(callsToAction) {
   );
 }
 
-const BaseAlertContainer = styled.div`
+const AlertContainer = styled.div`
    background-color: ${props => props.alertVariation.color};
    border: 1px solid ${props => props.alertVariation.borderColor};
    border-radius: 2px;
@@ -115,13 +142,18 @@ const BaseAlertContainer = styled.div`
    margin-bottom: 25px;
 `;
 
-const DismissableAlertContainer = styled(BaseAlertContainer)`
+const AlertContent = styled.div`
+  padding: 0 15px 15px;
+  margin-left: ${props => (props.hasIcon ? '22px' : '0')};
+`;
+
+const AlertHeader = styled.div`
   display: flex;
   justify-content: space-between;
 `;
 
-const AlertContent = styled.div`
-  padding: 15px;
+const AlertHeaderText = styled.div`
+  display: flex;
 `;
 
 function Alert({
@@ -133,14 +165,13 @@ function Alert({
   includeIcon = false,
   dismissable = false,
   onDismiss = noop,
+  extraNotificationText,
   ...otherProps
 }) {
   const alertVariation = alertVariations[type];
   const hasCallsToAction = callsToAction.length > 0;
-
-  const AlertContainer = dismissable
-    ? DismissableAlertContainer
-    : BaseAlertContainer;
+  const hasExtraNotification = extraNotificationText;
+  const hasChildren = React.Children.count(children) > 0;
 
   return (
     <AlertContainer
@@ -148,11 +179,19 @@ function Alert({
       alertVariation={alertVariation}
       role="alert"
     >
-      <AlertContent>
+      <AlertHeader>
         {renderLeadingHeader(type, includeIcon, header, additionalText)}
-        {children}
-      </AlertContent>
-      {dismissable ? renderDismissButton(onDismiss) : null}
+        <AlertHeaderText>
+          {hasExtraNotification
+            ? renderExtraNotification(extraNotificationText)
+            : null}
+          {dismissable ? renderDismissButton(onDismiss) : null}
+        </AlertHeaderText>
+      </AlertHeader>
+
+      {hasChildren
+        ? <AlertContent hasIcon={includeIcon}>{children}</AlertContent>
+        : null}
       {hasCallsToAction ? renderCallsToAction(callsToAction) : null}
     </AlertContainer>
   );
@@ -180,6 +219,8 @@ Alert.propTypes = {
   dismissable: PropTypes.bool,
   /** Function to execute when dismiss button is clicked */
   onDismiss: PropTypes.func,
+  /** The small text included in the extra notification */
+  extraNotificationText: PropTypes.string,
   callsToAction: PropTypes.arrayOf(PropTypes.shape(callToActionShape))
 };
 

--- a/src/components/containers/alert/Alert.js
+++ b/src/components/containers/alert/Alert.js
@@ -91,7 +91,7 @@ const NotificationIcon = styled(Icon)`
 
 function renderExtraNotification(notificationText) {
   return (
-    <ExtraNotification>
+    <ExtraNotification className="alert__notification">
       <NotificationIcon name="bell" />
       <small>{notificationText}</small>
     </ExtraNotification>

--- a/src/components/containers/alert/Alert.md
+++ b/src/components/containers/alert/Alert.md
@@ -83,6 +83,15 @@ const callsToAction = [
 />
 ```
 
+Providing ``extraNotificationText`` will render a bell icon and the provided text in the upper-right corner of the alert.
+```
+<Alert
+  type="success"
+  additionalText="Look at the extra notification!"
+  extraNotificationText="I'm a notification!"
+/>
+```
+
 Any additional children will get rendered before call to action buttons.
 ```
 <Alert

--- a/src/components/containers/alert/Alert.specs.js
+++ b/src/components/containers/alert/Alert.specs.js
@@ -99,3 +99,25 @@ describe('when callsToAction are provided', () => {
     expect(primaryAction.mock.calls.length).toBe(1);
   });
 });
+
+describe('when extraNotificationText is provided', () => {
+  const instanceProps = { extraNotificationText: 'test' };
+
+  let instance;
+
+  beforeEach(() => {
+    instance = getMountedInstance(instanceProps);
+  });
+
+  it('adds an ExtraNotification to the alert', () => {
+    expect(instance.find('.alert__notification').length).toBe(1);
+  });
+
+  it('displays the passed text as small', () => {
+    expect(instance.find('small').text()).toBe('test');
+  });
+
+  it('displays a static icon', () => {
+    expect(instance.find(Icon).length).toBe(1);
+  });
+});


### PR DESCRIPTION
This pull request adds a new prop and fixes some styling problems in the Alert component.

The new `extraNotificationText` prop is an optional prop that accepts strings and displays them beside a static bell icon in the upper right-hand corner of the Alert. 
This needs to be added as it is a missed design requirement from previous Alert iterations. 

The majority of styling fixes are to align the body text up with the leading header when an Icon is included in the Alert. This is because the body text currently lines up underneath the icon which is not the desired look.
Other styling fixes include:
- 15px spacing was added under the leading text and body text for better separation
- Icons were adjusted slightly to line up better with leading text
- containing elements were created/updated to allow for `includeIcon`, `extraNotificationText`, and `dismissable` to all be included without breaking styling

Alert tests and docs were also updated.  