### PR TITLE
Alert Fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "es-components",
-  "version": "3.5.4",
+  "version": "3.5.5",
   "description": "React components built for Exchange Solutions products",
   "repository": "https://github.com/TWExchangeSolutions/es-components",
   "main": "lib/index.js",

--- a/src/components/containers/alert/Alert.js
+++ b/src/components/containers/alert/Alert.js
@@ -73,9 +73,9 @@ function renderLeadingHeader(
     <LeadingHeader>
       {includeIcon ? renderIcon(alertType) : null}
       {hasLeadingHeaderText ? <strong>{leadingHeader}<br /></strong> : null}
-      <LeadingText adjustText={adjustText}>
-        {hasLeadingText ? leadingText : null}
-      </LeadingText>
+      {hasLeadingText
+        ? <LeadingText adjustText={adjustText}>{leadingText}</LeadingText>
+        : null}
     </LeadingHeader>
   );
 }


### PR DESCRIPTION
This is a fix for the Alert component to fix the conditional rendering of the `LeadingText` tag. 

My previous work had the rendering placed inside the `LeadingText` tag when the entire `LeadingText` tag needs to be conditionally rendered; otherwise, a span tag still renders and creates a larger 30px gap between the leading header and the body text. 

