### PR TITLE
Update Alert Component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "es-components",
-  "version": "3.5.6",
+  "version": "3.5.7",
   "description": "React components built for Exchange Solutions products",
   "repository": "https://github.com/TWExchangeSolutions/es-components",
   "main": "lib/index.js",

--- a/src/components/containers/alert/Alert.js
+++ b/src/components/containers/alert/Alert.js
@@ -86,13 +86,16 @@ const ExtraNotification = styled.p`
 `;
 
 const NotificationIcon = styled(Icon)`
-  margin-right: 10px;
+  margin-right: 7px;
+  margin-bottom: 2px;
 `;
 
-function renderExtraNotification(notificationText) {
+function renderExtraNotification(notification) {
+  const { notificationText, notificationIcon = 'federal' } = notification;
+
   return (
     <ExtraNotification className="alert__notification">
-      <NotificationIcon name="bell" />
+      <NotificationIcon name={notificationIcon} />
       <small>{notificationText}</small>
     </ExtraNotification>
   );
@@ -165,12 +168,12 @@ function Alert({
   includeIcon = false,
   dismissable = false,
   onDismiss = noop,
-  extraNotificationText,
+  extraNotification,
   ...otherProps
 }) {
   const alertVariation = alertVariations[type];
   const hasCallsToAction = callsToAction.length > 0;
-  const hasExtraNotification = extraNotificationText;
+  const hasExtraNotification = extraNotification;
   const hasChildren = React.Children.count(children) > 0;
 
   return (
@@ -183,7 +186,7 @@ function Alert({
         {renderLeadingHeader(type, includeIcon, header, additionalText)}
         <AlertHeaderText>
           {hasExtraNotification
-            ? renderExtraNotification(extraNotificationText)
+            ? renderExtraNotification(extraNotification)
             : null}
           {dismissable ? renderDismissButton(onDismiss) : null}
         </AlertHeaderText>
@@ -205,6 +208,11 @@ const callToActionShape = {
   action: PropTypes.func.isRequired
 };
 
+const extraNotificationShape = {
+  notificationText: PropTypes.node.isRequired,
+  notificationIcon: PropTypes.string
+};
+
 Alert.propTypes = {
   type: PropTypes.oneOf(alertTypes).isRequired,
   /** The bolded text in the leading text */
@@ -219,8 +227,8 @@ Alert.propTypes = {
   dismissable: PropTypes.bool,
   /** Function to execute when dismiss button is clicked */
   onDismiss: PropTypes.func,
-  /** The small text included in the extra notification */
-  extraNotificationText: PropTypes.string,
+  /** The small text and icon included in the extra notification */
+  extraNotification: PropTypes.shape(extraNotificationShape),
   callsToAction: PropTypes.arrayOf(PropTypes.shape(callToActionShape))
 };
 

--- a/src/components/containers/alert/Alert.md
+++ b/src/components/containers/alert/Alert.md
@@ -83,12 +83,17 @@ const callsToAction = [
 />
 ```
 
-Providing ``extraNotificationText`` will render a bell icon and the provided text in the upper-right corner of the alert.
+Providing ``extraNotification`` with an object will render the selected icon and the provided text in the upper-right corner of the alert. If no icon is chosen, the `federal` icon will be used by default.
 ```
+const notification = { 
+  notificationText: 'I\'m a notification!',
+  notificationIcon: 'bell'
+ };
+
 <Alert
   type="success"
   additionalText="Look at the extra notification!"
-  extraNotificationText="I'm a notification!"
+  extraNotification={notification}
 />
 ```
 

--- a/src/components/containers/alert/Alert.specs.js
+++ b/src/components/containers/alert/Alert.specs.js
@@ -118,7 +118,18 @@ describe('when extraNotificationText is provided', () => {
     expect(instance.find('small').text()).toBe('test');
   });
 
-  it('displays an icon', () => {
-    expect(instance.find(Icon).length).toBe(1);
+  it('displays the default icon', () => {
+    expect(instance.find(Icon).prop('name')).toBe('federal');
+  });
+
+  it('displays a different icon if provided one', () => {
+    const newNotification = {
+      notificationText: 'test',
+      notificationIcon: 'bell'
+    };
+
+    instance.setProps({ extraNotification: newNotification });
+
+    expect(instance.find(Icon).prop('name')).toBe('bell');
   });
 });

--- a/src/components/containers/alert/Alert.specs.js
+++ b/src/components/containers/alert/Alert.specs.js
@@ -101,7 +101,8 @@ describe('when callsToAction are provided', () => {
 });
 
 describe('when extraNotificationText is provided', () => {
-  const instanceProps = { extraNotificationText: 'test' };
+  const extraNotification = { notificationText: 'test' };
+  const instanceProps = { extraNotification };
 
   let instance;
 
@@ -117,7 +118,7 @@ describe('when extraNotificationText is provided', () => {
     expect(instance.find('small').text()).toBe('test');
   });
 
-  it('displays a static icon', () => {
+  it('displays an icon', () => {
     expect(instance.find(Icon).length).toBe(1);
   });
 });


### PR DESCRIPTION
I made changes to the `extraNotification` prop and functionality in the Alert component. 

These changes allow for the user to pass an icon name and choose their desired icon along with the text. The icon defaults to the `federal` icon.

Tests and docs have also been updated. 