### PR TITLE
Fix componentWillReceiveProps

### DIFF
--- a/src/components/patterns/incrementer/Incrementer.js
+++ b/src/components/patterns/incrementer/Incrementer.js
@@ -56,7 +56,11 @@ class Incrementer extends React.Component {
   }
 
   componentWillReceiveProps({ startingValue }) {
-    this.setState(this.determineDisabledStates(startingValue));
+    const disabledStates = this.determineDisabledStates(startingValue);
+    this.setState(() => ({
+      value: startingValue,
+      ...disabledStates
+    }));
   }
 
   componentWillUpdate(nextProps, nextState) {


### PR DESCRIPTION
I forgot to set the ``value`` field on the state object when new props are received. This PR makes sure that ``value`` gets set on the state in addition to the ``incrementButtonDisabled`` and ``decrementButtonDisabled`` values.

