### PR TITLE
Fix accessibility for Alert and PopoverLink

### DIFF
--- a/src/components/containers/alert/Alert.js
+++ b/src/components/containers/alert/Alert.js
@@ -192,11 +192,7 @@ function Alert({
   const hasChildren = React.Children.count(children) > 0;
 
   return (
-    <AlertContainer
-      {...otherProps}
-      alertVariation={alertVariation}
-      role="alert"
-    >
+    <AlertContainer {...otherProps} alertVariation={alertVariation}>
       <AlertHeader>
         {renderLeadingHeader(type, includeIcon, header, additionalText)}
         <div>

--- a/src/components/containers/popover/Popover.js
+++ b/src/components/containers/popover/Popover.js
@@ -148,7 +148,7 @@ const PopoverBodyContent = styled.div`
 
 const DismissPopover = styled(DismissButton)`
   color: ${props => (props.hasTitle ? colors.white : colors.grayDark)};
-  padding: ${props => (props.hasTitle ? '4px 14px' : '0px 14px')};
+  padding: ${props => (props.hasTitle ? '8px 14px' : '0px 14px')};
   margin-left: auto;
 `;
 
@@ -162,6 +162,7 @@ const PopoverHeader = styled.div`
 // className, positionLeft and positionTop props get passed to by the Overlay component
 const Popover = props => {
   const {
+    id,
     title,
     arrowPlacement,
     positionLeft,
@@ -179,6 +180,7 @@ const Popover = props => {
 
   return (
     <PopoverContent
+      id={id}
       className={popoverClassNames}
       role="tooltip"
       positionLeft={positionLeft}
@@ -201,6 +203,7 @@ const Popover = props => {
 };
 
 Popover.propTypes = {
+  id: PropTypes.string.isRequired,
   title: PropTypes.string,
   arrowPlacement: PropTypes.oneOf(['top', 'right', 'bottom', 'left']),
   positionLeft: PropTypes.number,

--- a/src/components/containers/popover/PopoverLink.js
+++ b/src/components/containers/popover/PopoverLink.js
@@ -40,6 +40,7 @@ class PopoverLink extends React.Component {
   render() {
     const {
       children,
+      popoverId,
       popoverTitle,
       popoverContent,
       popoverPlacement,
@@ -51,6 +52,7 @@ class PopoverLink extends React.Component {
 
     return (
       <PopoverTrigger
+        popoverId={popoverId}
         popoverTitle={popoverTitle}
         popoverContent={popoverContent}
         popoverTarget={this.popoverTarget}
@@ -65,7 +67,8 @@ class PopoverLink extends React.Component {
           }}
         >
           <PopoverButton
-            aria-haspopup="dialog"
+            aria-haspopup="true"
+            aria-describedby={popoverId}
             data-trigger="focus"
             styleType="link"
             handleOnClick={this.togglePopover}
@@ -85,6 +88,8 @@ class PopoverLink extends React.Component {
 PopoverLink.propTypes = {
   /** The link content which activates the popover */
   children: PropTypes.node.isRequired,
+  /** Helps identify the content element for accessibility */
+  popoverId: PropTypes.string.isRequired,
   /** The text displayed in the popover title section */
   popoverTitle: PropTypes.string,
   /** The content displayed in the popover body */

--- a/src/components/containers/popover/PopoverTrigger.js
+++ b/src/components/containers/popover/PopoverTrigger.js
@@ -21,6 +21,7 @@ function getArrowPlacement(popoverPlacement) {
 }
 
 function PopoverTrigger({
+  popoverId,
   popoverTitle,
   popoverContent,
   popoverTarget,
@@ -49,6 +50,7 @@ function PopoverTrigger({
         rootClose={!containsFormElement}
       >
         <Popover
+          id={popoverId}
           title={popoverTitle}
           arrowPlacement={arrowPlacement}
           containsFormElement={containsFormElement}
@@ -67,6 +69,7 @@ function PopoverTrigger({
 }
 
 PopoverTrigger.propTypes = {
+  popoverId: PropTypes.string.isRequired,
   popoverTitle: PropTypes.string,
   popoverContent: PropTypes.node.isRequired,
   popoverTarget: PropTypes.object,

--- a/src/components/controls/DismissButton.js
+++ b/src/components/controls/DismissButton.js
@@ -22,7 +22,7 @@ const ScreenReaderText = styled.span`
 `;
 
 const DismissButton = props => (
-  <DismissButtonBase aria-label="Close" {...props}>
+  <DismissButtonBase {...props}>
     <span aria-hidden="true">×</span>
     <ScreenReaderText>Close</ScreenReaderText>
   </DismissButtonBase>


### PR DESCRIPTION
Some observations while attempting to address some of the accessibility issues with Popover:

* **chromevox and chrome**
  * Working as expected
* **NVDA and chrome**
  * The content is read after tabbing into the link then hitting space to trigger the button, however it does not seem to to reread on subsequent triggers unless I tab away then tab back
* **NVDA and firefox** and **JAWS and IE**
  * Does not recognize that the popover has been opened

I'm still diagnosing what all can be done to help address this, but I can't seem to get the popover to be read in these last two browsers without having to use `role=alert`. The big different between what's going on in these changes and how bs3 is handling popovers is that the popover content lives directly next to the trigger.