### PR TITLE
Remove state from SideNav, Drawer, Textbox, add uncontrollable

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,9 +78,7 @@
     "lodash": "^4.17.4",
     "react-animate-height": "^0.9.11",
     "react-overlays": "^0.7.0",
-    "slug": "^0.9.1",
     "styled-components": "^2.0.0",
-    "tinycolor2": "^1.4.1",
-    "uncontrollable": "^4.1.0"
+    "tinycolor2": "^1.4.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "react-overlays": "^0.7.0",
     "slug": "^0.9.1",
     "styled-components": "^2.0.0",
-    "tinycolor2": "^1.4.1"
+    "tinycolor2": "^1.4.1",
+    "uncontrollable": "^4.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "react-animate-height": "^0.9.11",
     "react-overlays": "^0.7.0",
     "styled-components": "^2.0.0",
-    "tinycolor2": "^1.4.1"
+    "tinycolor2": "^1.4.1",
+    "uncontrollable": "^4.1.0"
   }
 }

--- a/src/components/containers/drawer/Drawer.js
+++ b/src/components/containers/drawer/Drawer.js
@@ -4,6 +4,7 @@ import DrawerPanel from './DrawerPanel';
 import { colors } from '../../theme';
 import styled from 'styled-components';
 import { noop } from 'lodash';
+import uncontrollable from 'uncontrollable';
 
 function drawerPanelPropType(props, propName, componentName) {
   const value = props[propName];
@@ -25,7 +26,7 @@ const StyledDrawer = styled.div`
   margin-bottom: 25px;
 `;
 
-const Drawer = props => {
+export const Drawer = props => {
   const {
     activeKeys,
     children,
@@ -99,6 +100,11 @@ Drawer.propTypes = {
   className: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
   /** Override the default plus icon with another OE icon name */
   closedIconName: PropTypes.string,
+  /** Used in uncontrolled mode to set initial drawer state */
+  defaultActiveKeys: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.arrayOf(PropTypes.string)
+  ]),
   /** Only allows one DrawerPanel to be open at a time */
   isAccordion: PropTypes.bool,
   /** Function called when changing active keys */
@@ -115,6 +121,10 @@ Drawer.defaultProps = {
   openedIconName: 'minus'
 };
 
-Drawer.Panel = DrawerPanel;
+const UncontrolledDrawer = uncontrollable(Drawer, {
+  activeKeys: 'onActiveKeysChanged'
+});
 
-export default Drawer;
+UncontrolledDrawer.Panel = DrawerPanel;
+
+export default UncontrolledDrawer;

--- a/src/components/containers/drawer/Drawer.js
+++ b/src/components/containers/drawer/Drawer.js
@@ -42,14 +42,6 @@ class Drawer extends Component {
     };
   }
 
-  componentWillReceiveProps(nextProps) {
-    if ('activeKeys' in nextProps) {
-      this.setState({
-        activeKeys: toArray(nextProps.activeKeys)
-      });
-    }
-  }
-
   onClickItem(key) {
     return () => {
       let activeKeys = [...this.state.activeKeys];
@@ -58,9 +50,9 @@ class Drawer extends Component {
         activeKeys = activeKeys[0] === key ? [] : [key];
       } else {
         const index = activeKeys.indexOf(key);
-        const isActive = index > -1;
+        const isOpen = index > -1;
 
-        if (isActive) {
+        if (isOpen) {
           activeKeys.splice(index, 1);
         } else {
           activeKeys.push(key);
@@ -76,15 +68,15 @@ class Drawer extends Component {
 
     return Children.map(this.props.children, (child, index) => {
       // If there is no key provided, use the panel order as default key
-      const key = child.key || String(index);
+      const key = child.key || String(index + 1);
       const { title, titleAside } = child.props;
       const noPadding = child.props.noPadding || false;
 
-      let isActive = false;
+      let isOpen = false;
       if (this.props.isAccordion) {
-        isActive = activeKeys[0] === key;
+        isOpen = activeKeys[0] === key;
       } else {
-        isActive = activeKeys.indexOf(key) > -1;
+        isOpen = activeKeys.indexOf(key) > -1;
       }
 
       const props = {
@@ -92,7 +84,7 @@ class Drawer extends Component {
         title,
         titleAside,
         noPadding,
-        isActive,
+        isOpen,
         children: child.props.children,
         onItemClick: this.onClickItem(key).bind(this),
         closedIconName: this.props.closedIconName,

--- a/src/components/containers/drawer/Drawer.md
+++ b/src/components/containers/drawer/Drawer.md
@@ -2,20 +2,37 @@ Use `Drawer` and `Drawer.Panel` components to wrap content in collapsable panels
 
 ### Basic Example
 ```
-<Drawer>
-  <Drawer.Panel title="Panel 1">
-    <p>Pretty much any content you want in here.</p>
-  </Drawer.Panel>
-  <Drawer.Panel title="Panel 2">
-    <p>More content you want in here.</p>
-  </Drawer.Panel>
-  <Drawer.Panel title="Panel 3">
-    <div>
-      More content. Anim pariatur cliche reprehenderit, enim eiusmod
-      high life accusamus terry richardson ad squid.
-    </div>
-  </Drawer.Panel>
-</Drawer>
+class DrawerExample extends React.Component {
+  constructor() {
+    this.state = { activeKeys: [] };
+    this.onActiveKeysChanged = this.onActiveKeysChanged.bind(this);
+  }
+
+  onActiveKeysChanged(value) {
+    this.setState({ activeKeys: value });
+  };
+
+  render() {
+    return (
+      <Drawer activeKeys={this.state.activeKeys} onActiveKeysChanged={this.onActiveKeysChanged}>
+        <Drawer.Panel title="Panel 1">
+          <p>Pretty much any content you want in here.</p>
+        </Drawer.Panel>
+        <Drawer.Panel title="Panel 2">
+          <p>More content you want in here.</p>
+        </Drawer.Panel>
+        <Drawer.Panel title="Panel 3">
+          <div>
+            More content. Anim pariatur cliche reprehenderit, enim eiusmod
+            high life accusamus terry richardson ad squid.
+          </div>
+        </Drawer.Panel>
+      </Drawer>
+    )
+  }
+}
+<DrawerExample />
+
 ```
 
 
@@ -23,23 +40,39 @@ Use `Drawer` and `Drawer.Panel` components to wrap content in collapsable panels
 Add the `isAccordion` property to change the default behavior to an accordion
 style, where only one panel can be opened at a time.
 ```
-<Drawer isAccordion>
-  <Drawer.Panel title="Accordion Panel 1">
-    <p>Pretty much any content you want in here.</p>
-  </Drawer.Panel>
-  <Drawer.Panel title="Accordion Panel 2" noPadding>
-    <ul>
-      <li>List Item</li>
-      <li>Another Item</li>
-    </ul>
-  </Drawer.Panel>
-  <Drawer.Panel title="Accordion Panel 3">
-    <div>
-      More content. Anim pariatur cliche reprehenderit, enim eiusmod
-      high life accusamus terry richardson ad squid.
-    </div>
-  </Drawer.Panel>
-</Drawer>
+class DrawerExample extends React.Component {
+  constructor() {
+    this.state = { activeKeys: [] };
+    this.onActiveKeysChanged = this.onActiveKeysChanged.bind(this);
+  }
+
+  onActiveKeysChanged(value) {
+    this.setState({ activeKeys: value });
+  };
+
+  render() {
+    return (
+      <Drawer isAccordion activeKeys={this.state.activeKeys} onActiveKeysChanged={this.onActiveKeysChanged}>
+        <Drawer.Panel title="Accordion Panel 1">
+          <p>Pretty much any content you want in here.</p>
+        </Drawer.Panel>
+        <Drawer.Panel title="Accordion Panel 2" noPadding>
+          <ul>
+            <li>List Item</li>
+            <li>Another Item</li>
+          </ul>
+        </Drawer.Panel>
+        <Drawer.Panel title="Accordion Panel 3">
+          <div>
+            More content. Anim pariatur cliche reprehenderit, enim eiusmod
+            high life accusamus terry richardson ad squid.
+          </div>
+        </Drawer.Panel>
+      </Drawer>
+    )
+  }
+}
+<DrawerExample />
 ```
 
 
@@ -52,21 +85,37 @@ matching the Panel's numeric position.
 Both the Drawer and Drawer.Panel components will accept additional classNames.
 
 ```
-<Drawer defaultActiveKeys={["first", "3"]} closedIconName="hand-right" openedIconName="hand-down" className="drawer-big">
-  <Drawer.Panel title="Panel One" key="first" noPadding titleAside={<em>aside text</em>}>
-    <p>The default padding has been removed from this panel.</p>
-  </Drawer.Panel>
-  <Drawer.Panel title="Panel Two" key="second" noPadding titleAside={<Icon name='tag' />}>
-    <ul>
-      <li>List Item</li>
-      <li>Another Item</li>
-    </ul>
-  </Drawer.Panel>
-  <Drawer.Panel title="Panel Three" className="alt-color">
-    <div>
-      More content. Anim pariatur cliche reprehenderit, enim eiusmod
-      high life accusamus terry richardson ad squid.
-    </div>
-  </Drawer.Panel>
-</Drawer>
+class DrawerExample extends React.Component {
+  constructor() {
+    this.state = { activeKeys: ["second","3"] };
+    this.onActiveKeysChanged = this.onActiveKeysChanged.bind(this);
+  }
+
+  onActiveKeysChanged(value) {
+    this.setState({ activeKeys: value });
+  };
+
+  render() {
+    return (
+      <Drawer activeKeys={this.state.activeKeys} onActiveKeysChanged={this.onActiveKeysChanged} closedIconName="hand-right" openedIconName="hand-down" className="drawer-big">
+        <Drawer.Panel title="Panel One" key="first" noPadding titleAside={<em>aside text</em>}>
+          <p>The default padding has been removed from this panel.</p>
+        </Drawer.Panel>
+        <Drawer.Panel title="Panel Two" key="second" noPadding titleAside={<Icon name='tag' />}>
+          <ul>
+            <li>List Item</li>
+            <li>Another Item</li>
+          </ul>
+        </Drawer.Panel>
+        <Drawer.Panel title="Panel Three" className="alt-color">
+          <div>
+            More content. Anim pariatur cliche reprehenderit, enim eiusmod
+            high life accusamus terry richardson ad squid.
+          </div>
+        </Drawer.Panel>
+      </Drawer>
+    )
+  }
+}
+<DrawerExample />
 ```

--- a/src/components/containers/drawer/Drawer.md
+++ b/src/components/containers/drawer/Drawer.md
@@ -46,21 +46,23 @@ style, where only one panel can be opened at a time.
 ### Advanced Example
 Use the ``noPadding`` property to remove default padding within a panel (useful for lists and tables).
 Use the ``titleAside`` property to display text or other content on the right side of the panel header.
-You can customize the ``key`` property of each Panel; if not specified the default is a zero-based array.
+You can customize the ``key`` property of each Panel; if not specified a default key value will be assigned
+matching the Panel's numeric position.
+
 Both the Drawer and Drawer.Panel components will accept additional classNames.
 
 ```
-<Drawer defaultActiveKeys={["first", "third"]} closedIconName="hand-right" openedIconName="hand-down" className="drawer-big">
-  <Drawer.Panel title="Panel 1" key="first" noPadding titleAside={<em>aside text</em>}>
+<Drawer defaultActiveKeys={["first", "3"]} closedIconName="hand-right" openedIconName="hand-down" className="drawer-big">
+  <Drawer.Panel title="Panel One" key="first" noPadding titleAside={<em>aside text</em>}>
     <p>The default padding has been removed from this panel.</p>
   </Drawer.Panel>
-  <Drawer.Panel title="Panel 2" key="second" noPadding titleAside={<Icon name='tag' />}>
+  <Drawer.Panel title="Panel Two" key="second" noPadding titleAside={<Icon name='tag' />}>
     <ul>
       <li>List Item</li>
       <li>Another Item</li>
     </ul>
   </Drawer.Panel>
-  <Drawer.Panel title="Panel 3" key="third" className="alt-color">
+  <Drawer.Panel title="Panel Three" className="alt-color">
     <div>
       More content. Anim pariatur cliche reprehenderit, enim eiusmod
       high life accusamus terry richardson ad squid.

--- a/src/components/containers/drawer/Drawer.md
+++ b/src/components/containers/drawer/Drawer.md
@@ -1,4 +1,4 @@
-Use ``Drawer`` and ``Drawer.Panel`` components to wrap content in collapsable panels.
+Use `Drawer` and `Drawer.Panel` components to wrap content in collapsable panels.
 
 ### Basic Example
 ```
@@ -20,7 +20,7 @@ Use ``Drawer`` and ``Drawer.Panel`` components to wrap content in collapsable pa
 
 
 ### Accordion
-Add the ``isAccordion`` property to change the default behavior to an accordion
+Add the `isAccordion` property to change the default behavior to an accordion
 style, where only one panel can be opened at a time.
 ```
 <Drawer isAccordion>
@@ -44,9 +44,9 @@ style, where only one panel can be opened at a time.
 
 
 ### Advanced Example
-Use the ``noPadding`` property to remove default padding within a panel (useful for lists and tables).
-Use the ``titleAside`` property to display text or other content on the right side of the panel header.
-You can customize the ``key`` property of each Panel; if not specified a default key value will be assigned
+Use the `noPadding` property to remove default padding within a panel (useful for lists and tables).
+Use the `titleAside` property to display text or other content on the right side of the panel header.
+You can customize the `key` property of each Panel; if not specified a default key value will be assigned
 matching the Panel's numeric position.
 
 Both the Drawer and Drawer.Panel components will accept additional classNames.

--- a/src/components/containers/drawer/Drawer.md
+++ b/src/components/containers/drawer/Drawer.md
@@ -1,82 +1,49 @@
-Use `Drawer` and `Drawer.Panel` components to wrap content in collapsable panels.
+Use `Drawer` and `Drawer.Panel` components to wrap content in collapsable panels. This component can be used in a controlled or uncontrolled way. When uncontrolled, you can specify `defaultActiveKeys` to set initial state. When controlled, you must supply both `activeKeys` and an `onActiveKeysChanged` handler.
 
-### Basic Example
+### Basic Example (Uncontrolled)
 ```
-class DrawerExample extends React.Component {
-  constructor() {
-    this.state = { activeKeys: [] };
-    this.onActiveKeysChanged = this.onActiveKeysChanged.bind(this);
-  }
-
-  onActiveKeysChanged(value) {
-    this.setState({ activeKeys: value });
-  };
-
-  render() {
-    return (
-      <Drawer activeKeys={this.state.activeKeys} onActiveKeysChanged={this.onActiveKeysChanged}>
-        <Drawer.Panel title="Panel 1">
-          <p>Pretty much any content you want in here.</p>
-        </Drawer.Panel>
-        <Drawer.Panel title="Panel 2">
-          <p>More content you want in here.</p>
-        </Drawer.Panel>
-        <Drawer.Panel title="Panel 3">
-          <div>
-            More content. Anim pariatur cliche reprehenderit, enim eiusmod
-            high life accusamus terry richardson ad squid.
-          </div>
-        </Drawer.Panel>
-      </Drawer>
-    )
-  }
-}
-<DrawerExample />
-
+<Drawer defaultActiveKeys={"1"}>
+  <Drawer.Panel title="Panel 1">
+    <p>Pretty much any content you want in here.</p>
+  </Drawer.Panel>
+  <Drawer.Panel title="Panel 2">
+    <p>More content you want in here.</p>
+  </Drawer.Panel>
+  <Drawer.Panel title="Panel 3">
+    <div>
+      More content. Anim pariatur cliche reprehenderit, enim eiusmod
+      high life accusamus terry richardson ad squid.
+    </div>
+  </Drawer.Panel>
+</Drawer>
 ```
 
 
-### Accordion
+### Accordion (Uncontrolled)
 Add the `isAccordion` property to change the default behavior to an accordion
 style, where only one panel can be opened at a time.
 ```
-class DrawerExample extends React.Component {
-  constructor() {
-    this.state = { activeKeys: [] };
-    this.onActiveKeysChanged = this.onActiveKeysChanged.bind(this);
-  }
-
-  onActiveKeysChanged(value) {
-    this.setState({ activeKeys: value });
-  };
-
-  render() {
-    return (
-      <Drawer isAccordion activeKeys={this.state.activeKeys} onActiveKeysChanged={this.onActiveKeysChanged}>
-        <Drawer.Panel title="Accordion Panel 1">
-          <p>Pretty much any content you want in here.</p>
-        </Drawer.Panel>
-        <Drawer.Panel title="Accordion Panel 2" noPadding>
-          <ul>
-            <li>List Item</li>
-            <li>Another Item</li>
-          </ul>
-        </Drawer.Panel>
-        <Drawer.Panel title="Accordion Panel 3">
-          <div>
-            More content. Anim pariatur cliche reprehenderit, enim eiusmod
-            high life accusamus terry richardson ad squid.
-          </div>
-        </Drawer.Panel>
-      </Drawer>
-    )
-  }
-}
-<DrawerExample />
+<Drawer isAccordion>
+  <Drawer.Panel title="Accordion Panel 1">
+    <p>Pretty much any content you want in here.</p>
+  </Drawer.Panel>
+  <Drawer.Panel title="Accordion Panel 2" noPadding>
+    <ul>
+      <li>List Item</li>
+      <li>Another Item</li>
+    </ul>
+  </Drawer.Panel>
+  <Drawer.Panel title="Accordion Panel 3">
+    <div>
+      More content. Anim pariatur cliche reprehenderit, enim eiusmod
+      high life accusamus terry richardson ad squid.
+    </div>
+  </Drawer.Panel>
+</Drawer>
 ```
 
 
-### Advanced Example
+### Advanced Example (Controlled)
 Use the `noPadding` property to remove default padding within a panel (useful for lists and tables).
 Use the `titleAside` property to display text or other content on the right side of the panel header.
 You can customize the `key` property of each Panel; if not specified a default key value will be assigned

--- a/src/components/containers/drawer/Drawer.specs.js
+++ b/src/components/containers/drawer/Drawer.specs.js
@@ -7,120 +7,100 @@ import Drawer from './Drawer';
 
 jest.mock('../../util/generateAlphaName', () => () => 'abcdef');
 
+const buildDrawer = props => (
+  <Drawer className="important" {...props}>
+    <Drawer.Panel
+      title="collapse 1"
+      key="1"
+      className="first"
+      titleAside="side text"
+    >
+      first
+    </Drawer.Panel>
+    <Drawer.Panel title="collapse 2" key="2" className="second" noPadding>
+      second
+    </Drawer.Panel>
+    <Drawer.Panel title="collapse 3" key="3" className="third">
+      third
+    </Drawer.Panel>
+  </Drawer>
+);
+
 describe('drawer component', () => {
   describe('drawer', () => {
-    let instanceToRender;
-
-    beforeEach(() => {
-      instanceToRender = (
-        <Drawer className="important">
-          <Drawer.Panel
-            title="collapse 1"
-            key="1"
-            className="first"
-            titleAside="side text"
-          >
-            first
-          </Drawer.Panel>
-          <Drawer.Panel title="collapse 2" key="2" className="second" noPadding>
-            second
-          </Drawer.Panel>
-          <Drawer.Panel title="collapse 3" key="3" className="third">
-            third
-          </Drawer.Panel>
-        </Drawer>
-      );
-    });
-
     it('renders as expected', () => {
-      const tree = renderer.create(instanceToRender).toJSON();
+      const tree = renderer.create(buildDrawer()).toJSON();
       expect(tree).toMatchSnapshot();
     });
 
-    it('click should toggle panel state', () => {
-      const drawerInstance = mount(instanceToRender);
+    it('clicking a closed panel should add panel key to activeKeys', () => {
+      const onActiveKeysChanged = jest.fn();
+      const drawerInstance = mount(buildDrawer({ onActiveKeysChanged }));
       const firstPanel = drawerInstance.find('.first');
       const panelButton = firstPanel.find('button');
 
       expect(panelButton.prop('aria-expanded')).toBe(false);
 
       panelButton.simulate('click');
+      expect(onActiveKeysChanged).toBeCalledWith(['1']);
+    });
+
+    it('clicking an open panel should remove panel key from activeKeys', () => {
+      const onActiveKeysChanged = jest.fn();
+      const drawerInstance = mount(
+        buildDrawer({ activeKeys: ['1'], onActiveKeysChanged })
+      );
+      const firstPanel = drawerInstance.find('.first');
+      const panelButton = firstPanel.find('button');
+
       expect(panelButton.prop('aria-expanded')).toBe(true);
 
       panelButton.simulate('click');
-      expect(panelButton.prop('aria-expanded')).toBe(false);
+      expect(onActiveKeysChanged).toBeCalledWith([]);
     });
 
-    it('should allow more than one drawer to be opened at a time', () => {
-      const drawerInstance = mount(instanceToRender);
+    it('should allow a second drawer to be opened', () => {
+      const onActiveKeysChanged = jest.fn();
+      const drawerInstance = mount(
+        buildDrawer({ activeKeys: ['1'], onActiveKeysChanged })
+      );
       const firstPanel = drawerInstance.find('.first');
       const firstButton = firstPanel.find('button');
       const thirdPanel = drawerInstance.find('.third');
       const thirdButton = thirdPanel.find('button');
 
-      expect(firstButton.prop('aria-expanded')).toBe(false);
-      expect(thirdButton.prop('aria-expanded')).toBe(false);
-
-      firstButton.simulate('click');
       expect(firstButton.prop('aria-expanded')).toBe(true);
       expect(thirdButton.prop('aria-expanded')).toBe(false);
 
       thirdButton.simulate('click');
-      expect(firstButton.prop('aria-expanded')).toBe(true);
-      expect(thirdButton.prop('aria-expanded')).toBe(true);
+      expect(onActiveKeysChanged).toBeCalledWith(['1', '3']);
     });
 
-    it('should set multiple default panels open at start', () => {
-      const drawerInstance = mount(
-        <Drawer defaultActiveKeys={['2', '3']}>
-          <Drawer.Panel title="collapse 1" key="1">first</Drawer.Panel>
-          <Drawer.Panel title="collapse 2" key="2">second</Drawer.Panel>
-          <Drawer.Panel title="collapse 3" key="3">third</Drawer.Panel>
-        </Drawer>
-      );
+    it('should allow rendering more than one active drawer', () => {
+      const drawerInstance = mount(buildDrawer({ activeKeys: ['1', '3'] }));
+      const firstPanel = drawerInstance.find('.first');
+      const firstButton = firstPanel.find('button');
+      const thirdPanel = drawerInstance.find('.third');
+      const thirdButton = thirdPanel.find('button');
 
-      const panels = drawerInstance.find('[aria-expanded]');
-      expect(panels.at(0).prop('aria-expanded')).toBe(false);
-      expect(panels.at(1).prop('aria-expanded')).toBe(true);
-      expect(panels.at(2).prop('aria-expanded')).toBe(true);
+      expect(firstButton.prop('aria-expanded')).toBe(true);
+      expect(thirdButton.prop('aria-expanded')).toBe(true);
     });
   });
 
   describe('accordion', () => {
-    let instanceToRender;
-
-    beforeEach(() => {
-      instanceToRender = (
-        <Drawer isAccordion defaultActiveKeys="1">
-          <Drawer.Panel title="collapse 1" key="1" className="first">
-            first
-          </Drawer.Panel>
-          <Drawer.Panel title="collapse 2" key="2" className="second">
-            second
-          </Drawer.Panel>
-          <Drawer.Panel title="collapse 3" key="3" className="third">
-            third
-          </Drawer.Panel>
-        </Drawer>
-      );
-    });
+    const isAccordion = true;
 
     it('renders as expected', () => {
-      const tree = renderer.create(instanceToRender).toJSON();
+      const tree = renderer.create(buildDrawer({ isAccordion })).toJSON();
       expect(tree).toMatchSnapshot();
     });
 
-    it('default active key should set panel open', () => {
-      const accordionInstance = mount(instanceToRender);
-      const panels = accordionInstance.find('[aria-expanded]');
-
-      expect(panels.at(0).prop('aria-expanded')).toBe(true);
-      expect(panels.at(1).prop('aria-expanded')).toBe(false);
-      expect(panels.at(2).prop('aria-expanded')).toBe(false);
-    });
-
     it('should only allow one drawer to be opened at a time', () => {
-      const accordionInstance = mount(instanceToRender);
+      const onActiveKeysChanged = jest.fn();
+      const accordionInstance = mount(
+        buildDrawer({ isAccordion, onActiveKeysChanged, activeKeys: ['1'] })
+      );
       const firstPanel = accordionInstance.find('.first');
       const firstButton = firstPanel.find('button');
       const thirdPanel = accordionInstance.find('.third');
@@ -130,8 +110,7 @@ describe('drawer component', () => {
       expect(thirdButton.prop('aria-expanded')).toBe(false);
 
       thirdButton.simulate('click');
-      expect(firstButton.prop('aria-expanded')).toBe(false);
-      expect(thirdButton.prop('aria-expanded')).toBe(true);
+      expect(onActiveKeysChanged).toBeCalledWith(['3']);
     });
   });
 });

--- a/src/components/containers/drawer/Drawer.specs.js
+++ b/src/components/containers/drawer/Drawer.specs.js
@@ -77,7 +77,10 @@ describe('drawer component', () => {
     });
 
     it('should allow rendering more than one active drawer', () => {
-      const drawerInstance = mount(buildDrawer({ activeKeys: ['1', '3'] }));
+      const onActiveKeysChanged = jest.fn();
+      const drawerInstance = mount(
+        buildDrawer({ activeKeys: ['1', '3'], onActiveKeysChanged })
+      );
       const firstPanel = drawerInstance.find('.first');
       const firstButton = firstPanel.find('button');
       const thirdPanel = drawerInstance.find('.third');

--- a/src/components/containers/drawer/DrawerPanel.js
+++ b/src/components/containers/drawer/DrawerPanel.js
@@ -6,9 +6,7 @@ import styled from 'styled-components';
 import genId from '../../util/generateAlphaName';
 import AnimateHeight from 'react-animate-height';
 
-const PanelWrapper = styled.div`
-  border-bottom: 1px solid ${colors.grayLight};
-`;
+const PanelWrapper = styled.div`border-bottom: 1px solid ${colors.grayLight};`;
 
 const PanelButton = styled.button`
   background: none;
@@ -32,9 +30,9 @@ const PanelIcon = styled(Icon)`
   top: -1px;
 `;
 
-const PanelBody = styled(({ noPadding, ...rest }) => (
+const PanelBody = styled(({ noPadding, ...rest }) =>
   <AnimateHeight {...rest} />
-))`
+)`
   background-color: ${colors.white};
   color: ${colors.grayDarkest};
 
@@ -49,7 +47,7 @@ const DrawerPanel = props => {
     children,
     className,
     closedIconName,
-    isActive,
+    isOpen,
     noPadding,
     onItemClick,
     openedIconName,
@@ -59,18 +57,22 @@ const DrawerPanel = props => {
 
   const headingAriaId = genId();
   const regionAriaId = genId();
-  const aside = titleAside !== undefined && <aside>{titleAside}</aside>;
+  const aside =
+    titleAside !== undefined &&
+    <aside>
+      {titleAside}
+    </aside>;
 
   return (
     <PanelWrapper className={className}>
       <div id={headingAriaId} role="heading">
         <PanelButton
-          aria-expanded={isActive}
+          aria-expanded={isOpen}
           aria-controls={regionAriaId}
           onClick={() => onItemClick()}
         >
           <span>
-            <PanelIcon name={isActive ? openedIconName : closedIconName} />
+            <PanelIcon name={isOpen ? openedIconName : closedIconName} />
             {title}
           </span>
           {aside}
@@ -79,7 +81,7 @@ const DrawerPanel = props => {
       <PanelBody
         aria-labelledby={headingAriaId}
         duration={300}
-        height={isActive ? 'auto' : 0}
+        height={isOpen ? 'auto' : 0}
         id={regionAriaId}
         noPadding={noPadding}
         role="region"
@@ -94,6 +96,7 @@ DrawerPanel.propTypes = {
   children: PropTypes.any.isRequired,
   /** Add additional CSS classes to the drawer item element */
   className: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
+  /** @ignore */
   closedIconName: PropTypes.string,
   /** Title text displayed next to the open/close icon */
   title: PropTypes.oneOfType([
@@ -103,15 +106,18 @@ DrawerPanel.propTypes = {
   ]).isRequired,
   /** Aside text/content displayed on the right side of the panel title */
   titleAside: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
-  isActive: PropTypes.bool,
+  /** @ignore */
+  isOpen: PropTypes.bool,
   /** Removes the default padding from the panel body */
   noPadding: PropTypes.bool,
+  /** @ignore */
   onItemClick: PropTypes.func,
+  /** @ignore */
   openedIconName: PropTypes.string
 };
 
 DrawerPanel.defaultProps = {
-  isActive: false,
+  isOpen: false,
   noPadding: false
 };
 

--- a/src/components/containers/drawer/DrawerPanel.md
+++ b/src/components/containers/drawer/DrawerPanel.md
@@ -1,1 +1,1 @@
-The ``DrawerPanel`` component is used within the Drawer component.
+The `DrawerPanel` component is used within the Drawer component.

--- a/src/components/containers/drawer/DrawerPanel.md
+++ b/src/components/containers/drawer/DrawerPanel.md
@@ -1,0 +1,1 @@
+The ``DrawerPanel`` component is used within the Drawer component.

--- a/src/components/containers/drawer/__snapshots__/Drawer.specs.js.snap
+++ b/src/components/containers/drawer/__snapshots__/Drawer.specs.js.snap
@@ -5,7 +5,7 @@ exports[`drawer component accordion renders as expected 1`] = `
   className="sc-EHOje ktKLsF"
 >
   <div
-    className="first sc-bwzfXH dYpfLQ"
+    className="first sc-bwzfXH fsHaqT"
   >
     <div
       id="abcdef"
@@ -50,7 +50,7 @@ exports[`drawer component accordion renders as expected 1`] = `
     </div>
   </div>
   <div
-    className="second sc-bwzfXH dYpfLQ"
+    className="second sc-bwzfXH fsHaqT"
   >
     <div
       id="abcdef"
@@ -95,7 +95,7 @@ exports[`drawer component accordion renders as expected 1`] = `
     </div>
   </div>
   <div
-    className="third sc-bwzfXH dYpfLQ"
+    className="third sc-bwzfXH fsHaqT"
   >
     <div
       id="abcdef"
@@ -147,7 +147,7 @@ exports[`drawer component drawer renders as expected 1`] = `
   className="important sc-EHOje ktKLsF"
 >
   <div
-    className="first sc-bwzfXH dYpfLQ"
+    className="first sc-bwzfXH fsHaqT"
   >
     <div
       id="abcdef"
@@ -195,7 +195,7 @@ exports[`drawer component drawer renders as expected 1`] = `
     </div>
   </div>
   <div
-    className="second sc-bwzfXH dYpfLQ"
+    className="second sc-bwzfXH fsHaqT"
   >
     <div
       id="abcdef"
@@ -240,7 +240,7 @@ exports[`drawer component drawer renders as expected 1`] = `
     </div>
   </div>
   <div
-    className="third sc-bwzfXH dYpfLQ"
+    className="third sc-bwzfXH fsHaqT"
   >
     <div
       id="abcdef"

--- a/src/components/containers/drawer/__snapshots__/Drawer.specs.js.snap
+++ b/src/components/containers/drawer/__snapshots__/Drawer.specs.js.snap
@@ -2,7 +2,7 @@
 
 exports[`drawer component accordion renders as expected 1`] = `
 <div
-  className="sc-EHOje ktKLsF"
+  className="important sc-EHOje ktKLsF"
 >
   <div
     className="first sc-bwzfXH fsHaqT"
@@ -13,32 +13,35 @@ exports[`drawer component accordion renders as expected 1`] = `
     >
       <button
         aria-controls="abcdef"
-        aria-expanded={true}
+        aria-expanded={false}
         className="sc-htpNat ebhkUu"
         onClick={[Function]}
       >
         <span>
           <i
             aria-hidden={true}
-            className="sc-bxivhb beQLQJ sc-bdVaJa dRgmsV"
-            content="63d"
+            className="sc-bxivhb beQLQJ sc-bdVaJa iOqSxE"
+            content="63f"
             fontFamily="oecom-icons"
             fontSize="inherit"
           />
           collapse 1
         </span>
+        <aside>
+          side text
+        </aside>
       </button>
     </div>
     <div
-      aria-hidden={false}
+      aria-hidden={true}
       aria-labelledby="abcdef"
-      className="rah-static rah-static--height-auto sc-ifAKCX gUdFEl"
+      className="rah-static rah-static--height-zero sc-ifAKCX gUdFEl"
       id="abcdef"
       role="region"
       style={
         Object {
-          "height": "auto",
-          "overflow": "visible",
+          "height": 0,
+          "overflow": "hidden",
         }
       }
     >
@@ -77,7 +80,7 @@ exports[`drawer component accordion renders as expected 1`] = `
     <div
       aria-hidden={true}
       aria-labelledby="abcdef"
-      className="rah-static rah-static--height-zero sc-ifAKCX gUdFEl"
+      className="rah-static rah-static--height-zero sc-ifAKCX lnWkgR"
       id="abcdef"
       role="region"
       style={

--- a/src/components/containers/fieldset/Fieldset.md
+++ b/src/components/containers/fieldset/Fieldset.md
@@ -1,4 +1,4 @@
-Use a ``Fieldset`` component to group related fields.
+Use a `Fieldset` component to group related fields.
 
 ### Fieldset example without a legend:
 ```

--- a/src/components/containers/modal/Modal.md
+++ b/src/components/containers/modal/Modal.md
@@ -1,6 +1,6 @@
-Use the ```closeButton``` attribute on the Modal.Header to show or hide the "X" button.
+Use the `closeButton` attribute on the Modal.Header to show or hide the "X" button.
 
-For accessbility, make sure to include the attribute ```aria-haspopup='dialog'``` on whatever link you create to activate the modal.
+For accessbility, make sure to include the attribute `aria-haspopup='dialog'` on whatever link you create to activate the modal.
 
 ```
 <div>

--- a/src/components/containers/notification/Notification.md
+++ b/src/components/containers/notification/Notification.md
@@ -33,7 +33,7 @@
 </div>
 ```
 
-Adding the ``dismissable`` prop will render a dismiss button that will execute the provided ``onDismiss`` function.
+Adding the `dismissable` prop will render a dismiss button that will execute the provided `onDismiss` function.
 ```
 <Notification
   type="success"
@@ -43,7 +43,7 @@ Adding the ``dismissable`` prop will render a dismiss button that will execute t
 />
 ```
 
-Adding the ``includeIcon`` prop will render an appropriate icon for the alert type. <em>If the viewport is less than 768px, it will not render any icons in the notification.</em>
+Adding the `includeIcon` prop will render an appropriate icon for the alert type. <em>If the viewport is less than 768px, it will not render any icons in the notification.</em>
 ```
 <Notification
   type="advisor"
@@ -52,7 +52,7 @@ Adding the ``includeIcon`` prop will render an appropriate icon for the alert ty
 />
 ```
 
-Providing ``callsToAction`` will render a button for each which executes that action. The first button will receive the ``primary`` style type and any additional button will receive the ``default`` style type.
+Providing `callsToAction` will render a button for each which executes that action. The first button will receive the `primary` style type and any additional button will receive the `default` style type.
 ```
 
 class CustomButton extends React.Component {
@@ -110,7 +110,7 @@ const callsToAction = [
 />
 ```
 
-Providing ``extraAlert`` with an object will render the selected icon and the provided text in the upper-right corner of the notification. If no icon is chosen, the `federal` icon will be used by default.
+Providing `extraAlert` with an object will render the selected icon and the provided text in the upper-right corner of the notification. If no icon is chosen, the `federal` icon will be used by default.
 ```
 const extraAlert = {
   alertText: 'I\'m an extra little alert!',

--- a/src/components/containers/tooltip/Tooltip.md
+++ b/src/components/containers/tooltip/Tooltip.md
@@ -1,4 +1,4 @@
-Use a ``Tooltip`` component to display a small hover tip over content.
+Use a `Tooltip` component to display a small hover tip over content.
 
 ### Basic Tooltip:
 ```

--- a/src/components/controls/buttons/Button.md
+++ b/src/components/controls/buttons/Button.md
@@ -33,7 +33,7 @@ function noop() { }
 
 ### Alternative button types
 
-Setting the ``alternative`` prop will give the button the alternative style for each type.
+Setting the `alternative` prop will give the button the alternative style for each type.
 
 ```
 const buttonExampleStyle = {
@@ -113,7 +113,7 @@ function noop() {}
 </div>
 ```
 
-Setting the ``block`` property will force the button to expand to the width of it's parent container.
+Setting the `block` property will force the button to expand to the width of it's parent container.
 
 ```
 const buttonContainerStyle = {
@@ -132,7 +132,7 @@ function noop() { }
 
 ```
 
-Any additional prop sent will be included on the button. For example, setting the ``disabled`` property will put the button into a disabled state, making it unclickable.
+Any additional prop sent will be included on the button. For example, setting the `disabled` property will put the button into a disabled state, making it unclickable.
 
 ```
 const buttonExampleStyle = {

--- a/src/components/controls/datepicker/DatePicker.md
+++ b/src/components/controls/datepicker/DatePicker.md
@@ -1,4 +1,4 @@
-The default date picker will start with current year and descend back 120 years. Selecting a date will run the passed ``daySelected`` function with the selected date as a parameter.
+The default date picker will start with current year and descend back 120 years. Selecting a date will run the passed `daySelected` function with the selected date as a parameter.
 
 ```
 function daySelected(date) {
@@ -12,7 +12,7 @@ function daySelected(date) {
 </div>
 ```
 
-Setting the ``descentAmount`` to anything less than 12 with a ``startingSelectionMode`` of "month" will start the datepicker with the day selection and suppress the ability to select a month without using the Previous and Next buttons.
+Setting the `descentAmount` to anything less than 12 with a `startingSelectionMode` of "month" will start the datepicker with the day selection and suppress the ability to select a month without using the Previous and Next buttons.
 
 ```
 function daySelected(date) {
@@ -26,7 +26,7 @@ function daySelected(date) {
 </div>
 ```
 
-Setting the ``preSelectedDate`` will set the currently selected date.
+Setting the `preSelectedDate` will set the currently selected date.
 
 ```
 function daySelected(date) {
@@ -39,4 +39,3 @@ function daySelected(date) {
   <div id="selected-date-ex-4" className="datepicker-example__result" />
 </div>
 ```
-

--- a/src/components/controls/dropdown/Dropdown.js
+++ b/src/components/controls/dropdown/Dropdown.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { noop, isNil } from 'lodash';
-import slug from 'slug';
 
 import Label from '../Label';
 import { LabelText, SelectBase } from '../BaseControls';
@@ -90,12 +89,14 @@ export default class Dropdown extends React.Component {
 
     const { currentValue } = this.state;
 
-    const firstOption = includeDefaultFirstOption
-      ? <option disabled value="">{firstOptionDisplayText}</option>
-      : null;
+    const firstOption = includeDefaultFirstOption ? (
+      <option disabled value="">
+        {firstOptionDisplayText}
+      </option>
+    ) : null;
 
     const selectOptions = options.map(opt => {
-      const optionKey = slug(opt.optionValue);
+      const optionKey = opt.optionValue.replace(/\s/g, '');
       return (
         <option key={optionKey} value={opt.optionValue}>
           {opt.optionText}
@@ -104,7 +105,6 @@ export default class Dropdown extends React.Component {
     });
 
     const selectVariables = getValidationStateVariables(validationState);
-    const selectName = name || slug(labelText);
 
     return (
       <Label inline={inline}>
@@ -115,7 +115,7 @@ export default class Dropdown extends React.Component {
           {labelText}
         </LabelText>
         <SelectBase
-          name={selectName}
+          name={name}
           value={currentValue}
           onChange={this.handleOptionChanged}
           onBlur={this.handleFocusLost}

--- a/src/components/controls/dropdown/Dropdown.md
+++ b/src/components/controls/dropdown/Dropdown.md
@@ -23,7 +23,7 @@ const options = [{
 </div>
 ```
 
-Passing an ``onOptionChanged`` function will execute with the value of the dropdown when the option has changed.
+Passing an `onOptionChanged` function will execute with the value of the dropdown when the option has changed.
 
 ```
 const options = [{
@@ -48,7 +48,7 @@ function onOptionChanged(value) {
 />
 ```
 
-Passing an ``onDropdownFocusLost`` function will execute with the value of the dropdown when the dropdown loses focus.
+Passing an `onDropdownFocusLost` function will execute with the value of the dropdown when the dropdown loses focus.
 
 ```
 const options = [{

--- a/src/components/controls/radio-buttons/RadioGroup.md
+++ b/src/components/controls/radio-buttons/RadioGroup.md
@@ -1,4 +1,4 @@
-Group radio buttons together using a ``RadioGroup`` component.
+Group radio buttons together using a `RadioGroup` component.
 
 ```
 const options = [{
@@ -15,7 +15,7 @@ const options = [{
 <RadioGroup name="colors" radioOptions={options} checkedValue="green" />
 ```
 
-Providing a ``legendText`` option will render a legend with the grouped radio buttons.
+Providing a `legendText` option will render a legend with the grouped radio buttons.
 
 ```
 const options = [{
@@ -36,7 +36,7 @@ const options = [{
 />
 ```
 
-Setting the ``inline`` option to false will stack the radio buttons
+Setting the `inline` option to false will stack the radio buttons
 
 ```
 const options = [{
@@ -57,7 +57,7 @@ const options = [{
 />
 ```
 
-Each radio is displayed as an error when the ``hasError`` prop is true. An errored radio group with a default checked option is rendered with a filled radio button.
+Each radio is displayed as an error when the `hasError` prop is true. An errored radio group with a default checked option is rendered with a filled radio button.
 
 ```
 const options = [{
@@ -98,7 +98,7 @@ const options = [{
 />
 ```
 
-Each radio is disabled when the ``disableAllOptions`` prop is true. A disabled radio group with a default checked option is rendered with a filled radio button.
+Each radio is disabled when the `disableAllOptions` prop is true. A disabled radio group with a default checked option is rendered with a filled radio button.
 
 ```
 const options = [{

--- a/src/components/controls/textbox/Textbox.md
+++ b/src/components/controls/textbox/Textbox.md
@@ -10,7 +10,7 @@
 </div>
 ```
 
-Pass a ``handleOnChange`` function to execute any time the input box value changes. This function will have the current value of the input box passed to it.
+Pass a `handleOnChange` function to execute any time the input box value changes. This function will have the current value of the input box passed to it.
 
 ```
 function onChange(value) {
@@ -23,7 +23,7 @@ function onChange(value) {
 />
 ```
 
-Pass a ``handleFocusLost`` function to execute when the text box loses focus. This function will have the current value of the input passed to it.
+Pass a `handleFocusLost` function to execute when the text box loses focus. This function will have the current value of the input passed to it.
 
 ```
 function onFocusLost(value) {
@@ -36,7 +36,7 @@ function onFocusLost(value) {
 />
 ```
 
-Adding an ``additionalHelpContent`` prop will provide additional help content underneath the text box.
+Adding an `additionalHelpContent` prop will provide additional help content underneath the text box.
 
 ```
 <Textbox
@@ -72,7 +72,7 @@ Adding an ``additionalHelpContent`` prop will provide additional help content un
 
 ### Appending and Prepending text
 
-Provide an ``appendText`` or ``prependText`` prop for appending and prepending inputs. Validation state colorings will also be applied.
+Provide an `appendText` or `prependText` prop for appending and prepending inputs. Validation state colorings will also be applied.
 
 ```
 <div>
@@ -119,7 +119,7 @@ Provide an ``appendText`` or ``prependText`` prop for appending and prepending i
 ### Additional props
 
 Any unspecified props that get passed get added as a prop to the input in order to allow for additional HTML attributes to be provided.
-The react ``autoFocus`` property is also accepted.
+The react `autoFocus` property is also accepted.
 
 #### Disabled and Readonly
 

--- a/src/components/controls/textbox/Textbox.md
+++ b/src/components/controls/textbox/Textbox.md
@@ -10,29 +10,44 @@
 </div>
 ```
 
-Pass a `handleOnChange` function to execute any time the input box value changes. This function will have the current value of the input box passed to it.
+Pass an `onChange` function to execute any time the input box value changes. This function will have the current value of the input box passed to it. The following is a simple controlled example, where state is handled outside the component. (See [Controlled Components](https://facebook.github.io/react/docs/forms.html#controlled-components) and [Uncontrolled Components](https://facebook.github.io/react/docs/uncontrolled-components.html).)
 
 ```
-function onChange(value) {
-  console.log(value);
+class TextboxExample extends React.Component {
+  constructor() {
+    this.state = { value: "" };
+    this.handleOnTextChange = this.handleOnTextChange.bind(this);
+  }
+
+  handleOnTextChange(value) {
+    console.log(value);
+    this.setState({ value });
+  }
+
+  render() {
+    return (
+      <Textbox
+        labelText="Controlled Example"
+        value={state.value}
+        onChange={this.handleOnTextChange}
+      />
+    )
+  }
 }
-
-<Textbox
-  labelText="First name"
-  handleOnChange={onChange}
-/>
+<TextboxExample />
 ```
 
-Pass a `handleFocusLost` function to execute when the text box loses focus. This function will have the current value of the input passed to it.
+Pass an `onBlur` function to execute when the text box loses focus. This function will have the current value of the input passed to it. To provide a default value in an uncontrolled `Textbox` component, use `defaultValue`.
 
 ```
-function onFocusLost(value) {
+function handleOnBlur(value) {
   confirm(`You entered ${value}. Is that correct?`);
 }
 
 <Textbox
+  defaultValue="Default"
   labelText="First name"
-  handleFocusLost={onFocusLost}
+  onBlur={handleOnBlur}
 />
 ```
 

--- a/src/components/controls/textbox/Textbox.specs.js
+++ b/src/components/controls/textbox/Textbox.specs.js
@@ -15,15 +15,11 @@ describe('Textbox component', () => {
   let instance;
   let input;
   const onChange = jest.fn();
-  const onFocusLost = jest.fn();
+  const onBlur = jest.fn();
 
   beforeEach(() => {
     instance = mount(
-      <Textbox
-        labelText="Text"
-        handleOnChange={onChange}
-        handleFocusLost={onFocusLost}
-      />
+      <Textbox labelText="Text" onChange={onChange} onBlur={onBlur} />
     );
 
     input = instance.find('input');
@@ -36,15 +32,7 @@ describe('Textbox component', () => {
 
   it('executes the handeFocusLost function when the input focus is lost with the value of the input', () => {
     input.simulate('blur', { target: { value: '' } });
-    expect(onFocusLost).toBeCalledWith('');
-  });
-
-  it('sets the state to the value when a handler is executed', () => {
-    input.simulate('blur', { target: { value: '' } });
-    expect(instance.state('currentValue')).toBe('');
-
-    input.simulate('change', { target: { value: 'text' } });
-    expect(instance.state('currentValue')).toBe('text');
+    expect(onBlur).toBeCalledWith('');
   });
 
   it('renders addon content when "prependContent" prop is passed', () => {

--- a/src/components/navigation/sidenav/NavItem.js
+++ b/src/components/navigation/sidenav/NavItem.js
@@ -107,7 +107,7 @@ const FlexSpan = styled.span`flex-grow: 1;`;
 
 const NavItem = props => {
   const {
-    altStyle,
+    useAltStyle,
     children,
     className,
     highlightedId,
@@ -124,7 +124,7 @@ const NavItem = props => {
     onClick(id);
   };
 
-  const AnchorStyled = altStyle ? AnchorAltStyle : AnchorBase;
+  const AnchorStyled = useAltStyle ? AnchorAltStyle : AnchorBase;
   const href = targetUrl || '#/';
   const openExternal = targetUrl && isExternalLink;
 
@@ -149,7 +149,7 @@ const NavItem = props => {
 
 NavItem.propTypes = {
   /** @ignore */
-  altStyle: PropTypes.bool,
+  useAltStyle: PropTypes.bool,
   /** Item content */
   children: PropTypes.any,
   /** Additional CSS classes to apply */
@@ -173,7 +173,7 @@ NavItem.propTypes = {
 };
 
 NavItem.defaultProps = {
-  altStyle: false,
+  useAltStyle: false,
   isDisabled: false,
   isExternalLink: false,
   onClick: noop

--- a/src/components/navigation/sidenav/NavItem.js
+++ b/src/components/navigation/sidenav/NavItem.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { colors } from '../../theme';
 import styled, { css } from 'styled-components';
@@ -27,42 +27,44 @@ const AnchorBase = styled.a`
     }
   }
 
-  ${props => props.isActive && css`
-    background-color: ${colors.accent};
-    color: ${colors.white};
-
-    &:hover {
+  ${props =>
+    props.isActive &&
+    css`
       background-color: ${colors.accent};
       color: ${colors.white};
 
-      > i {
+      &:hover {
+        background-color: ${colors.accent};
         color: ${colors.white};
+
+        > i {
+          color: ${colors.white};
+        }
       }
-    }
-  `}
+    `} ${props =>
+      props.isDisabled &&
+      css`
+        background-color: ${colors.grayLightest};
+        color: ${colors.grayDark};
+        cursor: not-allowed;
 
-  ${props => props.isDisabled && css`
-    background-color: ${colors.grayLightest};
-    color: ${colors.grayDark};
-    cursor: not-allowed;
+        > span {
+          pointer-events: none;
+        }
 
-    > span {
-      pointer-events: none;
-    }
+        > i {
+          color: ${colors.grayLightest};
+        }
 
-    > i {
-      color: ${colors.grayLightest};
-    }
+        &:hover {
+          background-color: ${colors.grayLightest};
+          color: ${colors.grayDark};
 
-    &:hover {
-      background-color: ${colors.grayLightest};
-      color: ${colors.grayDark};
-
-      > i {
-        color: ${colors.grayLightest};
-      }
-    }
-  `}
+          > i {
+            color: ${colors.grayLightest};
+          }
+        }
+      `};
 `;
 
 const AnchorAltStyle = AnchorBase.extend`
@@ -71,84 +73,79 @@ const AnchorAltStyle = AnchorBase.extend`
     padding-left: 6px;
   }
 
-  ${props => props.isActive && css`
-    background-color: ${colors.grayLight};
-    border-left: 4px solid ${colors.accent};
-    color: ${colors.accent};
-    padding-left: 6px;
-
-    > i {
-      color: ${colors.accent};
-    }
-
-    &:hover {
+  ${props =>
+    props.isActive &&
+    css`
       background-color: ${colors.grayLight};
+      border-left: 4px solid ${colors.accent};
       color: ${colors.accent};
+      padding-left: 6px;
 
       > i {
         color: ${colors.accent};
       }
-    }
-  `}
 
-  ${props => props.isDisabled && css`
-    &:hover {
-      border-left: none;
-      padding-left: 10px;
-    }
-  `}
+      &:hover {
+        background-color: ${colors.grayLight};
+        color: ${colors.accent};
+
+        > i {
+          color: ${colors.accent};
+        }
+      }
+    `} ${props =>
+      props.isDisabled &&
+      css`
+        &:hover {
+          border-left: none;
+          padding-left: 10px;
+        }
+      `};
 `;
 
-const FlexSpan = styled.span`
-  flex-grow: 1;
-`;
+const FlexSpan = styled.span`flex-grow: 1;`;
 
-class NavItem extends Component {
-  onNavItemClicked = () => {
-    const { onClick = noop, onNavClick } = this.props;
-    this.setState(() => {
-      onNavClick(this.props.id, null);
-      onClick(this.props.id, null);
-    });
+const NavItem = props => {
+  const {
+    altStyle,
+    children,
+    className,
+    highlightedId,
+    id,
+    isDisabled,
+    isExternalLink,
+    onClick,
+    onNavClick,
+    targetUrl
+  } = props;
+
+  const onNavItemClicked = () => {
+    onNavClick(id);
+    onClick(id);
   };
 
-  render() {
-    const {
-      altStyle = false,
-      children,
-      className,
-      highlightedId,
-      id,
-      isDisabled,
-      isExternalLink,
-      onNavClick = noop,
-      targetUrl
-    } = this.props;
+  const AnchorStyled = altStyle ? AnchorAltStyle : AnchorBase;
+  const href = targetUrl || '#/';
+  const openExternal = targetUrl && isExternalLink;
 
-    const AnchorStyled = altStyle ? AnchorAltStyle : AnchorBase;
-    const href = targetUrl || '#/';
-    const openExternal = targetUrl && isExternalLink;
+  const itemProps = {
+    className,
+    href,
+    isActive: id === highlightedId,
+    isDisabled,
+    onClick: isDisabled ? noop : onNavItemClicked,
+    ...(openExternal && { target: '_blank' })
+  };
 
-    const itemProps = {
-      className,
-      href,
-      isActive: id === highlightedId,
-      isDisabled,
-      onClick: isDisabled ? noop : this.onNavItemClicked,
-      onNavClick,
-      ...(openExternal && { target: '_blank' })
-    };
-
-    return (
-      <li>
-        <AnchorStyled {...itemProps}>
-          <FlexSpan>{children}</FlexSpan>
-          <Icon name="chevron-right" />
-        </AnchorStyled>
-      </li>
-    );
-  }
-}
+  return (
+    <li>
+      <AnchorStyled {...itemProps}>
+        <FlexSpan>{children}</FlexSpan>
+        <Icon name="chevron-right" />
+      </AnchorStyled>
+    </li>
+  );
+};
 
 NavItem.propTypes = {
   /** @ignore */
@@ -165,9 +162,9 @@ NavItem.propTypes = {
   isDisabled: PropTypes.bool,
   /** @ignore */
   isHighlighted: PropTypes.bool,
-  /** @ignore */
-  onClick: PropTypes.func,
   /** Used to assign an onClick event */
+  onClick: PropTypes.func,
+  /** @ignore */
   onNavClick: PropTypes.func,
   /** Sets the link to open in a new browser window */
   isExternalLink: PropTypes.bool,
@@ -176,9 +173,10 @@ NavItem.propTypes = {
 };
 
 NavItem.defaultProps = {
+  altStyle: false,
   isDisabled: false,
   isExternalLink: false,
-  onNavClick: noop
+  onClick: noop
 };
 
 export default NavItem;

--- a/src/components/navigation/sidenav/NavItem.md
+++ b/src/components/navigation/sidenav/NavItem.md
@@ -1,3 +1,1 @@
-```
-<p>NavItems are used within the SideNav component</p>
-```
+The ``NavItem`` component is used within the SideNav component.

--- a/src/components/navigation/sidenav/NavItem.md
+++ b/src/components/navigation/sidenav/NavItem.md
@@ -1,1 +1,1 @@
-The ``NavItem`` component is used within the SideNav component.
+The `NavItem` component is used within the SideNav component.

--- a/src/components/navigation/sidenav/SideNav.js
+++ b/src/components/navigation/sidenav/SideNav.js
@@ -18,7 +18,7 @@ const NavStyled = styled.nav`
 `;
 
 const SideNav = props => {
-  const { altStyle, children, onItemSelected, selected } = props;
+  const { useAltStyle, children, onItemSelected, selected } = props;
 
   const onNavClick = (navId = null) => {
     onItemSelected(navId);
@@ -31,7 +31,7 @@ const SideNav = props => {
           if (child !== null && child.type === NavItem) {
             const currentSelected = selected;
             return cloneElement(child, {
-              altStyle,
+              useAltStyle,
               highlightedId: currentSelected,
               onNavClick
             });
@@ -45,7 +45,7 @@ const SideNav = props => {
 
 SideNav.propTypes = {
   /** Use the alternate nav style */
-  altStyle: PropTypes.bool,
+  useAltStyle: PropTypes.bool,
   children: PropTypes.node,
   /** Use to manually select nav item by id, controlled mode */
   selected: PropTypes.string,
@@ -56,7 +56,7 @@ SideNav.propTypes = {
 };
 
 SideNav.defaultProps = {
-  altStyle: false,
+  useAltStyle: false,
   onItemSelected: noop
 };
 

--- a/src/components/navigation/sidenav/SideNav.js
+++ b/src/components/navigation/sidenav/SideNav.js
@@ -1,4 +1,4 @@
-import React, { Children, Component, cloneElement } from 'react';
+import React, { Children, cloneElement } from 'react';
 import PropTypes from 'prop-types';
 import { colors } from '../../theme';
 import styled from 'styled-components';
@@ -17,61 +17,47 @@ const NavStyled = styled.nav`
   }
 `;
 
-class SideNav extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      selected: props.defaultSelected,
-      defaultSelected: props.defaultSelected
-    };
-  }
+const SideNav = props => {
+  const { altStyle, children, onItemSelected, selected } = props;
 
-  onNavClick = (navId = null) => {
-    const { onItemSelected = noop } = this.props;
-
-    if (this.state.defaultSelected) {
-      this.setState({ selected: navId }, () => {
-        onItemSelected(navId);
-      });
-    } else {
-      onItemSelected(navId);
-    }
+  const onNavClick = (navId = null) => {
+    onItemSelected(navId);
   };
 
-  render() {
-    const { altStyle, children, selected } = this.props;
-    return (
-      <NavStyled>
-        <ul>
-          {Children.toArray(children).map(child => {
-            if (child !== null && child.type === NavItem) {
-              const currentSelected = this.state.defaultSelected
-                ? this.state.selected
-                : selected;
-              return cloneElement(child, {
-                altStyle,
-                highlightedId: currentSelected,
-                onClick: this.onNavClick
-              });
-            }
-            return child;
-          })}
-        </ul>
-      </NavStyled>
-    );
-  }
-}
+  return (
+    <NavStyled>
+      <ul>
+        {Children.toArray(children).map(child => {
+          if (child !== null && child.type === NavItem) {
+            const currentSelected = selected;
+            return cloneElement(child, {
+              altStyle,
+              highlightedId: currentSelected,
+              onNavClick
+            });
+          }
+          return child;
+        })}
+      </ul>
+    </NavStyled>
+  );
+};
 
 SideNav.propTypes = {
   /** Use the alternate nav style */
   altStyle: PropTypes.bool,
   children: PropTypes.node,
-  /** Use to manually select nav item by id, stateless mode */
+  /** Use to manually select nav item by id, controlled mode */
   selected: PropTypes.string,
-  /** Use to set a default nav, stateful mode */
+  /** Use to set a default nav, uncontrolled mode */
   defaultSelected: PropTypes.string,
   /** Function called when a nav item is clicked */
   onItemSelected: PropTypes.func
+};
+
+SideNav.defaultProps = {
+  altStyle: false,
+  onItemSelected: noop
 };
 
 SideNav.Item = NavItem;

--- a/src/components/navigation/sidenav/SideNav.js
+++ b/src/components/navigation/sidenav/SideNav.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { colors } from '../../theme';
 import styled from 'styled-components';
 import { noop } from 'lodash';
+import uncontrollable from 'uncontrollable';
 
 import NavItem from './NavItem';
 
@@ -17,7 +18,7 @@ const NavStyled = styled.nav`
   }
 `;
 
-const SideNav = props => {
+export const SideNav = props => {
   const { useAltStyle, children, onItemSelected, selected } = props;
 
   const onNavClick = (navId = null) => {
@@ -47,7 +48,7 @@ SideNav.propTypes = {
   /** Use the alternate nav style */
   useAltStyle: PropTypes.bool,
   children: PropTypes.node,
-  /** Use to manually select nav item by id, controlled mode */
+  /** Set the selected nav item by id, controlled mode */
   selected: PropTypes.string,
   /** Use to set a default nav, uncontrolled mode */
   defaultSelected: PropTypes.string,
@@ -60,6 +61,10 @@ SideNav.defaultProps = {
   onItemSelected: noop
 };
 
-SideNav.Item = NavItem;
+const UncontrolledSideNav = uncontrollable(SideNav, {
+  selected: 'onItemSelected'
+});
 
-export default SideNav;
+UncontrolledSideNav.Item = NavItem;
+
+export default UncontrolledSideNav;

--- a/src/components/navigation/sidenav/SideNav.md
+++ b/src/components/navigation/sidenav/SideNav.md
@@ -1,46 +1,31 @@
+(Uncontrolled) Use `defaultSelected` to set an initial selected item.
 ```
-class NavExample extends React.Component {
-  constructor() {
-    this.state = { selected: "home" };
-    this.onItemSelected = this.onItemSelected.bind(this);
-  }
+<div style={{display: 'flex'}}>
+  <div style={{width: '30%', marginRight: '4em'}}>
+    <h3>Standard</h3>
+    <SideNav defaultSelected="home">
+      <SideNav.Item id="home" targetUrl="#home">Home</SideNav.Item>
+      <SideNav.Item id="cart">Cart</SideNav.Item>
+      <SideNav.Item id="help">Help</SideNav.Item>
+      <SideNav.Item id="info">About</SideNav.Item>
+      <SideNav.Item id="disabled" isDisabled>Disabled</SideNav.Item>
+    </SideNav>
+  </div>
 
-  onItemSelected(value) {
-    this.setState({ selected: value });
-  };
-
-  render() {
-    return (
-      <div style={{display: 'flex'}}>
-        <div style={{width: '30%', marginRight: '4em'}}>
-          <h3>Standard</h3>
-          <SideNav selected={ this.state.selected } onItemSelected={ this.onItemSelected }>
-            <SideNav.Item id="home" targetUrl="#home">Home</SideNav.Item>
-            <SideNav.Item id="cart">Cart</SideNav.Item>
-            <SideNav.Item id="help">Help</SideNav.Item>
-            <SideNav.Item id="info">About</SideNav.Item>
-            <SideNav.Item id="disabled" isDisabled>Disabled</SideNav.Item>
-          </SideNav>
-        </div>
-
-        <div style={{width: '30%'}}>
-          <h3>Alternate Style</h3>
-          <SideNav selected={ this.state.selected } onItemSelected={ this.onItemSelected } useAltStyle>
-            <SideNav.Item id="home">Home</SideNav.Item>
-            <SideNav.Item id="cart">Cart</SideNav.Item>
-            <SideNav.Item id="help">Help</SideNav.Item>
-            <SideNav.Item id="info">About</SideNav.Item>
-            <SideNav.Item id="disabled" isDisabled>Disabled</SideNav.Item>
-          </SideNav>
-        </div>
-      </div>
-    )
-  }
-}
-<NavExample />
+  <div style={{width: '30%'}}>
+    <h3>Alternate Style</h3>
+    <SideNav useAltStyle defaultSelected="home">
+      <SideNav.Item id="home">Home</SideNav.Item>
+      <SideNav.Item id="cart">Cart</SideNav.Item>
+      <SideNav.Item id="help">Help</SideNav.Item>
+      <SideNav.Item id="info">About</SideNav.Item>
+      <SideNav.Item id="disabled" isDisabled>Disabled</SideNav.Item>
+    </SideNav>
+  </div>
+</div>
 ```
 
-Use `onItemSelected` to control the `selected` value.
+(Controlled) Use `onItemSelected` to control the `selected` value.
 ```
 class NavExample extends React.Component {
   constructor() {
@@ -68,56 +53,24 @@ class NavExample extends React.Component {
 <NavExample />
 ```
 
-Assign a `targetUrl` to set the nav link href location. Use `isExternalLink` to open the link in a new browser window.
-```
-class NavExample extends React.Component {
-  constructor() {
-    this.state = { selected: "home" };
-    this.onItemSelected = this.onItemSelected.bind(this);
-  }
-
-  onItemSelected(value) {
-    this.setState({ selected: value });
-  };
-
-  render() {
-    return (
-      <div style={{width: '30%'}}>
-        <SideNav selected={ this.state.selected } onItemSelected={ this.onItemSelected }>
-          <SideNav.Item id="home" targetUrl="/">Home</SideNav.Item>
-          <SideNav.Item id="medicare" targetUrl="https://medicare.oneexchange.com" isExternalLink>Medicare Site</SideNav.Item>
-          <SideNav.Item id="sidenav" targetUrl="#sidenav">SideNav Section</SideNav.Item>
-        </SideNav>
-      </div>
-    )
-  }
-}
-<NavExample />
-```
-
 Set `onClick` on an individual `SideNav.Item`.
 ```
-class NavExample extends React.Component {
-  constructor() {
-    this.state = { selected: "home" };
-    this.onItemSelected = this.onItemSelected.bind(this);
-  }
+<div style={{width: '30%'}}>
+  <SideNav useAltStyle>
+    <SideNav.Item id="home" onClick={ () => (alert('Time to go Home!'))}>Home</SideNav.Item>
+    <SideNav.Item id="cart" onClick={ () => (alert('You clicked the Cart!'))}>Cart</SideNav.Item>
+    <SideNav.Item id="disabled" isDisabled>Disabled</SideNav.Item>
+  </SideNav>
+</div>
+```
 
-  onItemSelected(value) {
-    this.setState({ selected: value });
-  };
-
-  render() {
-    return (
-      <div style={{width: '30%'}}>
-        <SideNav selected={ this.state.selected } onItemSelected={ this.onItemSelected } useAltStyle>
-          <SideNav.Item id="home" onClick={ () => (alert('Time to go Home!'))}>Home</SideNav.Item>
-          <SideNav.Item id="cart" onClick={ () => (alert('You clicked the Cart!'))}>Cart</SideNav.Item>
-          <SideNav.Item id="disabled" isDisabled>Disabled</SideNav.Item>
-        </SideNav>
-      </div>
-    )
-  }
-}
-<NavExample />
+Assign a `targetUrl` to set the nav link href location. Use `isExternalLink` to open the link in a new browser window.
+```
+<div style={{width: '30%'}}>
+  <SideNav>
+    <SideNav.Item id="home" targetUrl="/">Home</SideNav.Item>
+    <SideNav.Item id="medicare" targetUrl="https://medicare.oneexchange.com" isExternalLink>Medicare Site</SideNav.Item>
+    <SideNav.Item id="sidenav" targetUrl="#sidenav">SideNav Section</SideNav.Item>
+  </SideNav>
+</div>
 ```

--- a/src/components/navigation/sidenav/SideNav.md
+++ b/src/components/navigation/sidenav/SideNav.md
@@ -25,7 +25,7 @@ class NavExample extends React.Component {
 
         <div style={{width: '30%'}}>
           <h3>Alternate Style</h3>
-          <SideNav selected={ this.state.selected } onItemSelected={ this.onItemSelected } altStyle>
+          <SideNav selected={ this.state.selected } onItemSelected={ this.onItemSelected } useAltStyle>
             <SideNav.Item id="home">Home</SideNav.Item>
             <SideNav.Item id="cart">Cart</SideNav.Item>
             <SideNav.Item id="help">Help</SideNav.Item>
@@ -110,7 +110,7 @@ class NavExample extends React.Component {
   render() {
     return (
       <div style={{width: '30%'}}>
-        <SideNav selected={ this.state.selected } onItemSelected={ this.onItemSelected } altStyle>
+        <SideNav selected={ this.state.selected } onItemSelected={ this.onItemSelected } useAltStyle>
           <SideNav.Item id="home" onClick={ () => (alert('Time to go Home!'))}>Home</SideNav.Item>
           <SideNav.Item id="cart" onClick={ () => (alert('You clicked the Cart!'))}>Cart</SideNav.Item>
           <SideNav.Item id="disabled" isDisabled>Disabled</SideNav.Item>

--- a/src/components/navigation/sidenav/SideNav.md
+++ b/src/components/navigation/sidenav/SideNav.md
@@ -1,63 +1,106 @@
 ```
-<div style={{display: 'flex'}}>
-  <div style={{width: '30%', marginRight: '4em'}}>
-    <h3>Standard</h3>
-    <SideNav defaultSelected="home">
-      <SideNav.Item id="home" targetUrl="#home">Home</SideNav.Item>
-      <SideNav.Item id="cart">Cart</SideNav.Item>
-      <SideNav.Item id="help">Help</SideNav.Item>
-      <SideNav.Item id="info">About</SideNav.Item>
-      <SideNav.Item id="disabled" isDisabled>Disabled</SideNav.Item>
-    </SideNav>
-  </div>
+class NavExample extends React.Component {
+  constructor() {
+    super();
+    this.state = { selected: "home" };
+    this.onItemSelected = this.onItemSelected.bind(this);
+  }
 
-  <div style={{width: '30%'}}>
-    <h3>Alternate Style</h3>
-    <SideNav defaultSelected="home" altStyle>
-      <SideNav.Item id="home">Home</SideNav.Item>
-      <SideNav.Item id="cart">Cart</SideNav.Item>
-      <SideNav.Item id="help">Help</SideNav.Item>
-      <SideNav.Item id="info">About</SideNav.Item>
-      <SideNav.Item id="disabled" isDisabled>Disabled</SideNav.Item>
-    </SideNav>
-  </div>
-</div>
+  onItemSelected(value) {
+    this.setState({ selected: value });
+    alert(`${value} selected!`);
+  };
+
+  render() {
+    return (
+      <div style={{display: 'flex'}}>
+        <div style={{width: '30%', marginRight: '4em'}}>
+          <h3>Standard</h3>
+          <SideNav selected={ this.state.selected } onItemSelected={ this.onItemSelected }>
+            <SideNav.Item id="home" targetUrl="#home">Home</SideNav.Item>
+            <SideNav.Item id="cart">Cart</SideNav.Item>
+            <SideNav.Item id="help">Help</SideNav.Item>
+            <SideNav.Item id="info">About</SideNav.Item>
+            <SideNav.Item id="disabled" isDisabled>Disabled</SideNav.Item>
+          </SideNav>
+        </div>
+
+        <div style={{width: '30%'}}>
+          <h3>Alternate Style</h3>
+          <SideNav selected={ this.state.selected } onItemSelected={ this.onItemSelected } altStyle>
+            <SideNav.Item id="home">Home</SideNav.Item>
+            <SideNav.Item id="cart">Cart</SideNav.Item>
+            <SideNav.Item id="help">Help</SideNav.Item>
+            <SideNav.Item id="info">About</SideNav.Item>
+            <SideNav.Item id="disabled" isDisabled>Disabled</SideNav.Item>
+          </SideNav>
+        </div>
+      </div>
+    )
+  }
+}
+<NavExample />
+```
+
+Use `onItemSelected` to control the `selected` value.
+```
+class NavExample extends React.Component {
+  constructor() {
+    super();
+    this.state = { selected: "home" };
+    this.onItemSelected = this.onItemSelected.bind(this);
+  }
+
+  onItemSelected(value) {
+    this.setState({ selected: value });
+    alert(`${value} selected!`);
+  };
+
+  render() {
+    return (
+      <div style={{width: '30%'}}>
+        <SideNav selected={ this.state.selected } onItemSelected={ this.onItemSelected }>
+          <SideNav.Item id="home"><Icon name="home" /> Home</SideNav.Item>
+          <SideNav.Item id="cart"><Icon name="shopping-cart" /> Cart</SideNav.Item>
+          <SideNav.Item id="disabled" isDisabled><Icon name="ban-circle" /> Disabled</SideNav.Item>
+        </SideNav>
+      </div>
+    )
+  }
+}
+<NavExample />
 ```
 
 Assign a `targetUrl` to set the nav link href location. Use `isExternalLink` to open the link in a new browser window.
 ```
-<div style={{width: '30%'}}>
-  <SideNav defaultSelected="home">
-    <SideNav.Item id="home" targetUrl="/" onClick={ () => (alert('Time to go Home!'))}>Home</SideNav.Item>
-    <SideNav.Item id="medicare" targetUrl="https://medicare.oneexchange.com" isExternalLink>Medicare Site</SideNav.Item>
-    <SideNav.Item id="alerts" targetUrl="#alert">Alert Section</SideNav.Item>
-  </SideNav>
-</div>
-```
+class NavExample extends React.Component {
+  constructor() {
+    super();
+    this.state = { selected: "home" };
+    this.onItemSelected = this.onItemSelected.bind(this);
+  }
 
-Setting `onItemSelected` will execute the function when a `SideNav.Item` is clicked.
-```
-<div style={{width: '30%'}}>
-  <SideNav defaultSelected="home" onItemSelected={ (id) => {alert(id); }}>
-    <SideNav.Item id="home"><Icon name="home" /> Home</SideNav.Item>
-    <SideNav.Item id="cart"><Icon name="shopping-cart" /> Cart</SideNav.Item>
-    <SideNav.Item id="disabled" isDisabled><Icon name="ban-circle" /> Disabled</SideNav.Item>
-  </SideNav>
-</div>
+  onItemSelected(value) {
+    this.setState({ selected: value });
+    alert(`${value} selected!`);
+  };
+
+  render() {
+    return (
+      <div style={{width: '30%'}}>
+        <SideNav selected={ this.state.selected } onItemSelected={ this.onItemSelected }>
+          <SideNav.Item id="home" targetUrl="/" onClick={ () => (alert('Time to go Home!'))}>Home</SideNav.Item>
+          <SideNav.Item id="medicare" targetUrl="https://medicare.oneexchange.com" isExternalLink>Medicare Site</SideNav.Item>
+          <SideNav.Item id="sidenav" targetUrl="#sidenav">SideNav Section</SideNav.Item>
+        </SideNav>
+      </div>
+    )
+  }
+}
+<NavExample />
 ```
 
 Set `onClick` on an individual `SideNav.Item`.
-```
-<div style={{width: '30%'}}>
-  <SideNav defaultSelected="home" altStyle>
-    <SideNav.Item id="home" onClick={ () => (alert('Time to go Home!'))}>Home</SideNav.Item>
-    <SideNav.Item id="cart" onClick={ () => (alert('You clicked the Cart!'))}>Cart</SideNav.Item>
-    <SideNav.Item id="disabled" isDisabled>Disabled</SideNav.Item>
-  </SideNav>
-</div>
-```
-
-Manage selected item state manually (controlled mode) using `selected` instead of `defaultSelected`.
 ```
 class NavExample extends React.Component {
   constructor() {
@@ -73,10 +116,10 @@ class NavExample extends React.Component {
   render() {
     return (
       <div style={{width: '30%'}}>
-        <SideNav selected={this.state.selected} onItemSelected={this.onItemSelected}>
-          <SideNav.Item id="home">Home</SideNav.Item>
-          <SideNav.Item id="cart">Cart</SideNav.Item>
-          <SideNav.Item id="help">Help</SideNav.Item>
+        <SideNav selected={ this.state.selected } onItemSelected={ this.onItemSelected } altStyle>
+          <SideNav.Item id="home" onClick={ () => (alert('Time to go Home!'))}>Home</SideNav.Item>
+          <SideNav.Item id="cart" onClick={ () => (alert('You clicked the Cart!'))}>Cart</SideNav.Item>
+          <SideNav.Item id="disabled" isDisabled>Disabled</SideNav.Item>
         </SideNav>
       </div>
     )

--- a/src/components/navigation/sidenav/SideNav.md
+++ b/src/components/navigation/sidenav/SideNav.md
@@ -24,18 +24,18 @@
 </div>
 ```
 
-Assign a ```targetUrl``` to set the nav link href location. Use ```isExternalLink``` to open the link in a new browser window.
+Assign a `targetUrl` to set the nav link href location. Use `isExternalLink` to open the link in a new browser window.
 ```
 <div style={{width: '30%'}}>
   <SideNav defaultSelected="home">
-    <SideNav.Item id="home" targetUrl="/" onNavClick={ () => (alert('Time to go Home!'))}>Home</SideNav.Item>
+    <SideNav.Item id="home" targetUrl="/" onClick={ () => (alert('Time to go Home!'))}>Home</SideNav.Item>
     <SideNav.Item id="medicare" targetUrl="https://medicare.oneexchange.com" isExternalLink>Medicare Site</SideNav.Item>
     <SideNav.Item id="alerts" targetUrl="#alert">Alert Section</SideNav.Item>
   </SideNav>
 </div>
 ```
 
-Setting ```onItemSelected``` will execute the function when a ```SideNav.Item``` is clicked.
+Setting `onItemSelected` will execute the function when a `SideNav.Item` is clicked.
 ```
 <div style={{width: '30%'}}>
   <SideNav defaultSelected="home" onItemSelected={ (id) => {alert(id); }}>
@@ -46,24 +46,41 @@ Setting ```onItemSelected``` will execute the function when a ```SideNav.Item```
 </div>
 ```
 
-Set ```onNavClick``` on an individual ```SideNav.Item```.
+Set `onClick` on an individual `SideNav.Item`.
 ```
 <div style={{width: '30%'}}>
   <SideNav defaultSelected="home" altStyle>
-    <SideNav.Item id="home" onNavClick={ () => (alert('Time to go Home!'))}>Home</SideNav.Item>
-    <SideNav.Item id="cart" onNavClick={ () => (alert('You clicked the Cart!'))}>Cart</SideNav.Item>
+    <SideNav.Item id="home" onClick={ () => (alert('Time to go Home!'))}>Home</SideNav.Item>
+    <SideNav.Item id="cart" onClick={ () => (alert('You clicked the Cart!'))}>Cart</SideNav.Item>
     <SideNav.Item id="disabled" isDisabled>Disabled</SideNav.Item>
   </SideNav>
 </div>
 ```
 
-Manage selected item state manually using ```selected``` instead of ```defaultSelected```.
+Manage selected item state manually (controlled mode) using `selected` instead of `defaultSelected`.
 ```
-<div style={{width: '30%'}}>
-  <SideNav selected={state.selected} onItemSelected={ (id) => {setState({selected: id})} }>
-    <SideNav.Item id="home">Home</SideNav.Item>
-    <SideNav.Item id="cart">Cart</SideNav.Item>
-    <SideNav.Item id="help">Help</SideNav.Item>
-  </SideNav>
-</div>
+class NavExample extends React.Component {
+  constructor() {
+    super();
+    this.state = { selected: "home" };
+    this.onItemSelected = this.onItemSelected.bind(this);
+  }
+
+  onItemSelected(value) {
+    this.setState({ selected: value });
+  };
+
+  render() {
+    return (
+      <div style={{width: '30%'}}>
+        <SideNav selected={this.state.selected} onItemSelected={this.onItemSelected}>
+          <SideNav.Item id="home">Home</SideNav.Item>
+          <SideNav.Item id="cart">Cart</SideNav.Item>
+          <SideNav.Item id="help">Help</SideNav.Item>
+        </SideNav>
+      </div>
+    )
+  }
+}
+<NavExample />
 ```

--- a/src/components/navigation/sidenav/SideNav.md
+++ b/src/components/navigation/sidenav/SideNav.md
@@ -1,14 +1,12 @@
 ```
 class NavExample extends React.Component {
   constructor() {
-    super();
     this.state = { selected: "home" };
     this.onItemSelected = this.onItemSelected.bind(this);
   }
 
   onItemSelected(value) {
     this.setState({ selected: value });
-    alert(`${value} selected!`);
   };
 
   render() {
@@ -46,7 +44,6 @@ Use `onItemSelected` to control the `selected` value.
 ```
 class NavExample extends React.Component {
   constructor() {
-    super();
     this.state = { selected: "home" };
     this.onItemSelected = this.onItemSelected.bind(this);
   }
@@ -75,21 +72,19 @@ Assign a `targetUrl` to set the nav link href location. Use `isExternalLink` to 
 ```
 class NavExample extends React.Component {
   constructor() {
-    super();
     this.state = { selected: "home" };
     this.onItemSelected = this.onItemSelected.bind(this);
   }
 
   onItemSelected(value) {
     this.setState({ selected: value });
-    alert(`${value} selected!`);
   };
 
   render() {
     return (
       <div style={{width: '30%'}}>
         <SideNav selected={ this.state.selected } onItemSelected={ this.onItemSelected }>
-          <SideNav.Item id="home" targetUrl="/" onClick={ () => (alert('Time to go Home!'))}>Home</SideNav.Item>
+          <SideNav.Item id="home" targetUrl="/">Home</SideNav.Item>
           <SideNav.Item id="medicare" targetUrl="https://medicare.oneexchange.com" isExternalLink>Medicare Site</SideNav.Item>
           <SideNav.Item id="sidenav" targetUrl="#sidenav">SideNav Section</SideNav.Item>
         </SideNav>
@@ -104,7 +99,6 @@ Set `onClick` on an individual `SideNav.Item`.
 ```
 class NavExample extends React.Component {
   constructor() {
-    super();
     this.state = { selected: "home" };
     this.onItemSelected = this.onItemSelected.bind(this);
   }

--- a/src/components/navigation/sidenav/SideNav.specs.js
+++ b/src/components/navigation/sidenav/SideNav.specs.js
@@ -8,15 +8,14 @@ import SideNav from './SideNav';
 describe('drawer', () => {
   let instanceToRender;
   const onItemSelected = jest.fn();
-  const onNavClick = jest.fn();
+  const onClick = jest.fn();
 
   beforeEach(() => {
     onItemSelected.mockClear();
-    onNavClick.mockClear();
+    onClick.mockClear();
 
     instanceToRender = (
       <SideNav
-        defaultSelected="home"
         onItemSelected={navId => {
           onItemSelected(navId);
         }}
@@ -24,12 +23,14 @@ describe('drawer', () => {
         <SideNav.Item
           id="home"
           className="home"
-          onNavClick={navId => onNavClick(navId)}
+          onClick={navId => onClick(navId)}
           targetUrl="/home"
         >
           Home
         </SideNav.Item>
-        <SideNav.Item id="cart" className="cart">Cart</SideNav.Item>
+        <SideNav.Item id="cart" className="cart">
+          Cart
+        </SideNav.Item>
         <SideNav.Item
           id="external"
           className="external"
@@ -41,7 +42,7 @@ describe('drawer', () => {
         <SideNav.Item
           id="info"
           className="info"
-          onNavClick={() => onNavClick()}
+          onClick={() => onClick()}
           isDisabled
         >
           Disabled
@@ -55,16 +56,6 @@ describe('drawer', () => {
     expect(tree).toMatchSnapshot();
   });
 
-  it('sets the selected state', () => {
-    const navInstance = mount(instanceToRender);
-    expect(navInstance.state('selected')).toBe('home');
-
-    const navItem = navInstance.find('.cart');
-    navItem.simulate('click');
-
-    expect(navInstance.state('selected')).toBe('cart');
-  });
-
   it('executes onItemSelected with the id of the nav item clicked', () => {
     const navInstance = mount(instanceToRender);
     const navItem = navInstance.find('.cart');
@@ -73,12 +64,12 @@ describe('drawer', () => {
     expect(onItemSelected).toBeCalledWith('cart');
   });
 
-  it('executes onNavClick when nav item clicked', () => {
+  it('executes onClick when nav item clicked', () => {
     const navInstance = mount(instanceToRender);
     const navItem = navInstance.find('.home');
 
     navItem.simulate('click');
-    expect(onNavClick).toBeCalledWith('home');
+    expect(onClick).toBeCalledWith('home');
   });
 
   it('disabled item prevents onclick functions', () => {
@@ -86,7 +77,7 @@ describe('drawer', () => {
     const navItem = navInstance.find('.info');
 
     navItem.simulate('click');
-    expect(onNavClick).not.toBeCalled();
+    expect(onClick).not.toBeCalled();
     expect(onItemSelected).not.toBeCalled();
   });
 });

--- a/src/components/navigation/sidenav/__snapshots__/SideNav.specs.js.snap
+++ b/src/components/navigation/sidenav/__snapshots__/SideNav.specs.js.snap
@@ -7,12 +7,12 @@ exports[`drawer renders as expected 1`] = `
   <ul>
     <li>
       <a
-        className="home sc-bwzfXH jEMmwW"
+        className="home sc-bwzfXH kdkTdX"
         href="/home"
         onClick={[Function]}
       >
         <span
-          className="sc-bxivhb khxFsg"
+          className="sc-bxivhb gYEJOJ"
         >
           Home
         </span>
@@ -27,12 +27,12 @@ exports[`drawer renders as expected 1`] = `
     </li>
     <li>
       <a
-        className="cart sc-bwzfXH jEMmwW"
+        className="cart sc-bwzfXH kdkTdX"
         href="#/"
         onClick={[Function]}
       >
         <span
-          className="sc-bxivhb khxFsg"
+          className="sc-bxivhb gYEJOJ"
         >
           Cart
         </span>
@@ -47,13 +47,13 @@ exports[`drawer renders as expected 1`] = `
     </li>
     <li>
       <a
-        className="external sc-bwzfXH jEMmwW"
+        className="external sc-bwzfXH kdkTdX"
         href="http://www.google.com"
         onClick={[Function]}
         target="_blank"
       >
         <span
-          className="sc-bxivhb khxFsg"
+          className="sc-bxivhb gYEJOJ"
         >
           External Link
         </span>
@@ -68,12 +68,12 @@ exports[`drawer renders as expected 1`] = `
     </li>
     <li>
       <a
-        className="info sc-bwzfXH dWICOj"
+        className="info sc-bwzfXH echfcF"
         href="#/"
         onClick={[Function]}
       >
         <span
-          className="sc-bxivhb khxFsg"
+          className="sc-bxivhb gYEJOJ"
         >
           Disabled
         </span>

--- a/src/components/navigation/sidenav/__snapshots__/SideNav.specs.js.snap
+++ b/src/components/navigation/sidenav/__snapshots__/SideNav.specs.js.snap
@@ -7,7 +7,7 @@ exports[`drawer renders as expected 1`] = `
   <ul>
     <li>
       <a
-        className="home sc-bwzfXH kEPtnz"
+        className="home sc-bwzfXH jEMmwW"
         href="/home"
         onClick={[Function]}
       >

--- a/src/components/patterns/datepicker-textbox/DatePickerTextbox.js
+++ b/src/components/patterns/datepicker-textbox/DatePickerTextbox.js
@@ -17,8 +17,6 @@ const dateFormat = 'M/D/YYYY';
 export default class DatePickerTextbox extends React.Component {
   static propTypes = {
     labelText: PropTypes.string.isRequired,
-    /** Textbox component used to trigger the DatePicker display */
-    textComponent: PropTypes.func,
     /** Function to execute with the formatted date */
     dateSelected: PropTypes.func,
     /** The currently selected date */
@@ -31,8 +29,7 @@ export default class DatePickerTextbox extends React.Component {
     dateSelected: noop,
     handleTextboxChanged: noop,
     handleTextboxFocusLost: noop,
-    datePickerProps: {},
-    textComponent: Textbox
+    datePickerProps: {}
   };
 
   constructor(props) {
@@ -50,15 +47,10 @@ export default class DatePickerTextbox extends React.Component {
     this.displayPicker = this.displayPicker.bind(this);
     this.hidePicker = this.hidePicker.bind(this);
     this.togglePicker = this.togglePicker.bind(this);
-    this.setPopoverTarget = this.setPopoverTarget.bind(this);
   }
 
   componentWillReceiveProps({ preselectedDate }) {
     this.setState(() => ({ preselectedDate }));
-  }
-
-  setPopoverTarget(ref) {
-    this.popoverTarget = ref.prependRef;
   }
 
   togglePicker() {
@@ -102,7 +94,7 @@ export default class DatePickerTextbox extends React.Component {
   }
 
   render() {
-    const { labelText, datePickerProps, textComponent } = this.props;
+    const { labelText, datePickerProps } = this.props;
     const { displayPicker, preselectedDate } = this.state;
     const prependedIcon = <Icon name="calendar" />;
 
@@ -115,27 +107,31 @@ export default class DatePickerTextbox extends React.Component {
     );
 
     const textProps = {
-      ref: this.setPopoverTarget,
       labelText,
       prependContent: prependedIcon,
       onFocus: this.displayPicker,
       onClick: this.togglePicker,
-      handleOnChange: this.dateTextboxChanged,
-      handleFocusLost: this.dateTextboxFocusLost,
-      initialValue: format(preselectedDate, dateFormat),
+      onChange: this.dateTextboxChanged,
+      onBlur: this.dateTextboxFocusLost,
+      value: format(preselectedDate, dateFormat),
       ...this.props
     };
 
     return (
       <PopoverTrigger
         popoverContent={popoverContent}
-        popoverTarget={this.popoverTarget}
+        popoverTarget={this.addon}
         shouldDisplayPopover={displayPicker}
         onHideOverlay={this.hidePicker}
         containsFormElement
         popoverPlacement="top"
       >
-        {React.createElement(textComponent, textProps)}
+        <Textbox
+          {...textProps}
+          prependAddonRef={addon => {
+            this.addon = addon;
+          }}
+        />
       </PopoverTrigger>
     );
   }

--- a/src/components/patterns/datepicker-textbox/DatePickerTextbox.md
+++ b/src/components/patterns/datepicker-textbox/DatePickerTextbox.md
@@ -1,4 +1,4 @@
-The datepicker will be displayed when the textbox is clicked or focused on. The `DatePickerTextbox` component can be passed an object with props that will propagate to the `DatePicker` component.
+The datepicker will be displayed when the textbox is clicked or focused on. The `DatePickerTextbox` component can be passed an object with `DatePicker` component props.
 
 ```
 const datePickerProps = {

--- a/src/components/patterns/datepicker-textbox/DatePickerTextbox.md
+++ b/src/components/patterns/datepicker-textbox/DatePickerTextbox.md
@@ -1,4 +1,4 @@
-The datepicker will be displayed when the textbox is clicked or focused on. The ``DatePickerTextbox`` component can be passed an object with props that will propagate to the ``DatePicker`` component.
+The datepicker will be displayed when the textbox is clicked or focused on. The `DatePickerTextbox` component can be passed an object with props that will propagate to the `DatePicker` component.
 
 ```
 const datePickerProps = {
@@ -13,7 +13,7 @@ When a date is already selected, it will set the DatePicker to that particular d
 <DatePickerTextbox labelText="Birth Date" preselectedDate="1/21/1983" />
 ```
 
-When the textbox loses focus, it will run the passed in ``dateSelected`` function with the date formatted properly if it is a valid date:
+When the textbox loses focus, it will run the passed in `dateSelected` function with the date formatted properly if it is a valid date:
 
 ```
 function displayDate(date) {

--- a/src/components/patterns/incrementer/Incrementer.md
+++ b/src/components/patterns/incrementer/Incrementer.md
@@ -20,7 +20,7 @@ Thresholds can be set that will set a range for values that the incrementer will
 />
 ```
 
-Passing a function to ``onValueUpdated`` will execute that function with the new value.
+Passing a function to `onValueUpdated` will execute that function with the new value.
 
 ```
 function printNewValue(value) {


### PR DESCRIPTION
Removed state from SideNav, Drawer, and Textbox components, implemented uncontrollable wrapper on Drawer component, various other minor changes/cleanup detailed below.

SideNav:
1. Renamed some props in SideNav to be more standard (like onNavChange -> onChange) or for clarity (altStyle -> useAltStyle)
2. Converted SideNav and NavItem from classes to functions, removing state
3. Updated docs and samples for SideNav
4. Wrapped as uncontrollable component, now works controlled or uncontrolled

Drawer:
1. Added onActiveKeysChanged callback, removed defaultActiveKeys prop
2. Converted Drawer from class to function, removed state
3. Renamed Drawer prop isActive -> isOpen
4. Wrapped as uncontrollable component, now works controlled or uncontrolled

Textbox:
1. Removed state as it isn't necessary; form elements maintain their own state ([Uncontrolled Components](https://facebook.github.io/react/docs/uncontrolled-components.html))

Other:
1. Removed slug from project and its usage in the Dropdown component
2. Updated docs using inline code markdown to use a consistent single tick (sorry, I know it's a little OCD)