### PR TITLE
Fixed mixed usage of backticks

### DIFF
--- a/src/components/base/icons/Icon.md
+++ b/src/components/base/icons/Icon.md
@@ -17,4 +17,4 @@ const containerStyle = {
 </div>
 ```
 
-**Note:** Icons will not work if the ``oecom-icons`` and ``oe-icons-light`` font faces are not loaded into a stylesheet prior to using the Icon component.
+**Note:** Icons will not work if the `oecom-icons` and `oe-icons-light` font faces are not loaded into a stylesheet prior to using the Icon component.

--- a/src/components/containers/drawer/Drawer.md
+++ b/src/components/containers/drawer/Drawer.md
@@ -1,4 +1,4 @@
-Use ``Drawer`` and ``Drawer.Panel`` components to wrap content in collapsable panels.
+Use `Drawer` and `Drawer.Panel` components to wrap content in collapsable panels.
 
 ### Basic Example
 ```
@@ -20,7 +20,7 @@ Use ``Drawer`` and ``Drawer.Panel`` components to wrap content in collapsable pa
 
 
 ### Accordion
-Add the ``isAccordion`` property to change the default behavior to an accordion
+Add the `isAccordion` property to change the default behavior to an accordion
 style, where only one panel can be opened at a time.
 ```
 <Drawer isAccordion>
@@ -44,9 +44,9 @@ style, where only one panel can be opened at a time.
 
 
 ### Advanced Example
-Use the ``noPadding`` property to remove default padding within a panel (useful for lists and tables).
-Use the ``titleAside`` property to display text or other content on the right side of the panel header.
-You can customize the ``key`` property of each Panel; if not specified the default is a zero-based array.
+Use the `noPadding` property to remove default padding within a panel (useful for lists and tables).
+Use the `titleAside` property to display text or other content on the right side of the panel header.
+You can customize the `key` property of each Panel; if not specified the default is a zero-based array.
 Both the Drawer and Drawer.Panel components will accept additional classNames.
 
 ```

--- a/src/components/containers/fieldset/Fieldset.md
+++ b/src/components/containers/fieldset/Fieldset.md
@@ -1,4 +1,4 @@
-Use a ``Fieldset`` component to group related fields.
+Use a `Fieldset` component to group related fields.
 
 ### Fieldset example without a legend:
 ```

--- a/src/components/containers/modal/Modal.md
+++ b/src/components/containers/modal/Modal.md
@@ -1,6 +1,6 @@
-Use the ```closeButton``` attribute on the Modal.Header to show or hide the "X" button.
+Use the `closeButton` attribute on the Modal.Header to show or hide the "X" button.
 
-For accessbility, make sure to include the attribute ```aria-haspopup='dialog'``` on whatever link you create to activate the modal.
+For accessbility, make sure to include the attribute `aria-haspopup='dialog'` on whatever link you create to activate the modal.
 
 ```
 <div>

--- a/src/components/containers/notification/Notification.md
+++ b/src/components/containers/notification/Notification.md
@@ -33,7 +33,7 @@
 </div>
 ```
 
-Adding the ``dismissable`` prop will render a dismiss button that will execute the provided ``onDismiss`` function.
+Adding the `dismissable` prop will render a dismiss button that will execute the provided `onDismiss` function.
 ```
 <Notification
   type="success"
@@ -43,7 +43,7 @@ Adding the ``dismissable`` prop will render a dismiss button that will execute t
 />
 ```
 
-Adding the ``includeIcon`` prop will render an appropriate icon for the alert type. <em>If the viewport is less than 768px, it will not render any icons in the notification.</em>
+Adding the `includeIcon` prop will render an appropriate icon for the alert type. <em>If the viewport is less than 768px, it will not render any icons in the notification.</em>
 ```
 <Notification
   type="advisor"
@@ -52,7 +52,7 @@ Adding the ``includeIcon`` prop will render an appropriate icon for the alert ty
 />
 ```
 
-Providing ``callsToAction`` will render a button for each which executes that action. The first button will receive the ``primary`` style type and any additional button will receive the ``default`` style type.
+Providing `callsToAction` will render a button for each which executes that action. The first button will receive the `primary` style type and any additional button will receive the `default` style type.
 ```
 
 class CustomButton extends React.Component {
@@ -110,7 +110,7 @@ const callsToAction = [
 />
 ```
 
-Providing ``extraAlert`` with an object will render the selected icon and the provided text in the upper-right corner of the notification. If no icon is chosen, the `federal` icon will be used by default.
+Providing `extraAlert` with an object will render the selected icon and the provided text in the upper-right corner of the notification. If no icon is chosen, the `federal` icon will be used by default.
 ```
 const extraAlert = {
   alertText: 'I\'m an extra little alert!',

--- a/src/components/containers/tooltip/Tooltip.md
+++ b/src/components/containers/tooltip/Tooltip.md
@@ -1,4 +1,4 @@
-Use a ``Tooltip`` component to display a small hover tip over content.
+Use a `Tooltip` component to display a small hover tip over content.
 
 ### Basic Tooltip:
 ```

--- a/src/components/controls/buttons/Button.md
+++ b/src/components/controls/buttons/Button.md
@@ -33,7 +33,7 @@ function noop() { }
 
 ### Alternative button types
 
-Setting the ``alternative`` prop will give the button the alternative style for each type.
+Setting the `alternative` prop will give the button the alternative style for each type.
 
 ```
 const buttonExampleStyle = {
@@ -113,7 +113,7 @@ function noop() {}
 </div>
 ```
 
-Setting the ``block`` property will force the button to expand to the width of it's parent container.
+Setting the `block` property will force the button to expand to the width of it's parent container.
 
 ```
 const buttonContainerStyle = {
@@ -132,7 +132,7 @@ function noop() { }
 
 ```
 
-Any additional prop sent will be included on the button. For example, setting the ``disabled`` property will put the button into a disabled state, making it unclickable.
+Any additional prop sent will be included on the button. For example, setting the `disabled` property will put the button into a disabled state, making it unclickable.
 
 ```
 const buttonExampleStyle = {

--- a/src/components/controls/datepicker/DatePicker.md
+++ b/src/components/controls/datepicker/DatePicker.md
@@ -1,4 +1,4 @@
-The default date picker will start with current year and descend back 120 years. Selecting a date will run the passed ``daySelected`` function with the selected date as a parameter.
+The default date picker will start with current year and descend back 120 years. Selecting a date will run the passed `daySelected` function with the selected date as a parameter.
 
 ```
 function daySelected(date) {
@@ -12,7 +12,7 @@ function daySelected(date) {
 </div>
 ```
 
-Setting the ``descentAmount`` to anything less than 12 with a ``startingSelectionMode`` of "month" will start the datepicker with the day selection and suppress the ability to select a month without using the Previous and Next buttons.
+Setting the `descentAmount` to anything less than 12 with a `startingSelectionMode` of "month" will start the datepicker with the day selection and suppress the ability to select a month without using the Previous and Next buttons.
 
 ```
 function daySelected(date) {
@@ -26,7 +26,7 @@ function daySelected(date) {
 </div>
 ```
 
-Setting the ``preSelectedDate`` will set the currently selected date.
+Setting the `preSelectedDate` will set the currently selected date.
 
 ```
 function daySelected(date) {
@@ -39,4 +39,3 @@ function daySelected(date) {
   <div id="selected-date-ex-4" className="datepicker-example__result" />
 </div>
 ```
-

--- a/src/components/controls/dropdown/Dropdown.md
+++ b/src/components/controls/dropdown/Dropdown.md
@@ -23,7 +23,7 @@ const options = [{
 </div>
 ```
 
-Passing an ``onOptionChanged`` function will execute with the value of the dropdown when the option has changed.
+Passing an `onOptionChanged` function will execute with the value of the dropdown when the option has changed.
 
 ```
 const options = [{
@@ -48,7 +48,7 @@ function onOptionChanged(value) {
 />
 ```
 
-Passing an ``onDropdownFocusLost`` function will execute with the value of the dropdown when the dropdown loses focus.
+Passing an `onDropdownFocusLost` function will execute with the value of the dropdown when the dropdown loses focus.
 
 ```
 const options = [{

--- a/src/components/controls/radio-buttons/RadioGroup.md
+++ b/src/components/controls/radio-buttons/RadioGroup.md
@@ -1,4 +1,4 @@
-Group radio buttons together using a ``RadioGroup`` component.
+Group radio buttons together using a `RadioGroup` component.
 
 ```
 const options = [{
@@ -15,7 +15,7 @@ const options = [{
 <RadioGroup name="colors" radioOptions={options} checkedValue="green" />
 ```
 
-Providing a ``legendText`` option will render a legend with the grouped radio buttons.
+Providing a `legendText` option will render a legend with the grouped radio buttons.
 
 ```
 const options = [{
@@ -36,7 +36,7 @@ const options = [{
 />
 ```
 
-Setting the ``inline`` option to false will stack the radio buttons
+Setting the `inline` option to false will stack the radio buttons
 
 ```
 const options = [{
@@ -57,7 +57,7 @@ const options = [{
 />
 ```
 
-Each radio is displayed as an error when the ``hasError`` prop is true. An errored radio group with a default checked option is rendered with a filled radio button.
+Each radio is displayed as an error when the `hasError` prop is true. An errored radio group with a default checked option is rendered with a filled radio button.
 
 ```
 const options = [{
@@ -98,7 +98,7 @@ const options = [{
 />
 ```
 
-Each radio is disabled when the ``disableAllOptions`` prop is true. A disabled radio group with a default checked option is rendered with a filled radio button.
+Each radio is disabled when the `disableAllOptions` prop is true. A disabled radio group with a default checked option is rendered with a filled radio button.
 
 ```
 const options = [{

--- a/src/components/controls/textbox/Textbox.md
+++ b/src/components/controls/textbox/Textbox.md
@@ -10,7 +10,7 @@
 </div>
 ```
 
-Pass a ``handleOnChange`` function to execute any time the input box value changes. This function will have the current value of the input box passed to it.
+Pass a `handleOnChange` function to execute any time the input box value changes. This function will have the current value of the input box passed to it.
 
 ```
 function onChange(value) {
@@ -23,7 +23,7 @@ function onChange(value) {
 />
 ```
 
-Pass a ``handleFocusLost`` function to execute when the text box loses focus. This function will have the current value of the input passed to it.
+Pass a `handleFocusLost` function to execute when the text box loses focus. This function will have the current value of the input passed to it.
 
 ```
 function onFocusLost(value) {
@@ -36,7 +36,7 @@ function onFocusLost(value) {
 />
 ```
 
-Adding an ``additionalHelpContent`` prop will provide additional help content underneath the text box.
+Adding an `additionalHelpContent` prop will provide additional help content underneath the text box.
 
 ```
 <Textbox
@@ -72,7 +72,7 @@ Adding an ``additionalHelpContent`` prop will provide additional help content un
 
 ### Appending and Prepending text
 
-Provide an ``appendText`` or ``prependText`` prop for appending and prepending inputs. Validation state colorings will also be applied.
+Provide an `appendText` or `prependText` prop for appending and prepending inputs. Validation state colorings will also be applied.
 
 ```
 <div>
@@ -119,7 +119,7 @@ Provide an ``appendText`` or ``prependText`` prop for appending and prepending i
 ### Additional props
 
 Any unspecified props that get passed get added as a prop to the input in order to allow for additional HTML attributes to be provided.
-The react ``autoFocus`` property is also accepted.
+The react `autoFocus` property is also accepted.
 
 #### Disabled and Readonly
 

--- a/src/components/navigation/sidenav/SideNav.md
+++ b/src/components/navigation/sidenav/SideNav.md
@@ -24,7 +24,7 @@
 </div>
 ```
 
-Assign a ```targetUrl``` to set the nav link href location. Use ```isExternalLink``` to open the link in a new browser window.
+Assign a `targetUrl` to set the nav link href location. Use `isExternalLink` to open the link in a new browser window.
 ```
 <div style={{width: '30%'}}>
   <SideNav defaultSelected="home">
@@ -35,7 +35,7 @@ Assign a ```targetUrl``` to set the nav link href location. Use ```isExternalLin
 </div>
 ```
 
-Setting ```onItemSelected``` will execute the function when a ```SideNav.Item``` is clicked.
+Setting `onItemSelected` will execute the function when a `SideNav.Item` is clicked.
 ```
 <div style={{width: '30%'}}>
   <SideNav defaultSelected="home" onItemSelected={ (id) => {alert(id); }}>
@@ -46,7 +46,7 @@ Setting ```onItemSelected``` will execute the function when a ```SideNav.Item```
 </div>
 ```
 
-Set ```onNavClick``` on an individual ```SideNav.Item```.
+Set `onNavClick` on an individual `SideNav.Item`.
 ```
 <div style={{width: '30%'}}>
   <SideNav defaultSelected="home" altStyle>
@@ -57,7 +57,7 @@ Set ```onNavClick``` on an individual ```SideNav.Item```.
 </div>
 ```
 
-Manage selected item state manually using ```selected``` instead of ```defaultSelected```.
+Manage selected item state manually using `selected` instead of `defaultSelected`.
 ```
 <div style={{width: '30%'}}>
   <SideNav selected={state.selected} onItemSelected={ (id) => {setState({selected: id})} }>

--- a/src/components/patterns/datepicker-textbox/DatePickerTextbox.md
+++ b/src/components/patterns/datepicker-textbox/DatePickerTextbox.md
@@ -1,4 +1,4 @@
-The datepicker will be displayed when the textbox is clicked or focused on. The ``DatePickerTextbox`` component can be passed an object with props that will propagate to the ``DatePicker`` component.
+The datepicker will be displayed when the textbox is clicked or focused on. The `DatePickerTextbox` component can be passed an object with props that will propagate to the `DatePicker` component.
 
 ```
 const datePickerProps = {
@@ -13,7 +13,7 @@ When a date is already selected, it will set the DatePicker to that particular d
 <DatePickerTextbox labelText="Birth Date" preselectedDate="1/21/1983" />
 ```
 
-When the textbox loses focus, it will run the passed in ``dateSelected`` function with the date formatted properly if it is a valid date:
+When the textbox loses focus, it will run the passed in `dateSelected` function with the date formatted properly if it is a valid date:
 
 ```
 function displayDate(date) {

--- a/src/components/patterns/incrementer/Incrementer.md
+++ b/src/components/patterns/incrementer/Incrementer.md
@@ -20,7 +20,7 @@ Thresholds can be set that will set a range for values that the incrementer will
 />
 ```
 
-Passing a function to ``onValueUpdated`` will execute that function with the new value.
+Passing a function to `onValueUpdated` will execute that function with the new value.
 
 ```
 function printNewValue(value) {


### PR DESCRIPTION
Simple change to make markdown in docs consistent.  Inline code text only requires a single backtick.