### PR TITLE
Drawer refactor

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "react-overlays": "^0.7.0",
     "slug": "^0.9.1",
     "styled-components": "^2.0.0",
-    "tinycolor2": "^1.4.1"
+    "tinycolor2": "^1.4.1",
+    "uncontrollable": "^4.1.0"
   }
 }

--- a/src/components/containers/drawer/Drawer.js
+++ b/src/components/containers/drawer/Drawer.js
@@ -1,16 +1,10 @@
-import React, { Children, Component } from 'react';
+import React, { Children } from 'react';
 import PropTypes from 'prop-types';
 import DrawerPanel from './DrawerPanel';
 import { colors } from '../../theme';
 import styled from 'styled-components';
-
-function toArray(activeKeys) {
-  let currentActiveKeys = activeKeys;
-  if (!Array.isArray(currentActiveKeys)) {
-    currentActiveKeys = currentActiveKeys ? [currentActiveKeys] : [];
-  }
-  return currentActiveKeys;
-}
+import { noop } from 'lodash';
+import uncontrollable from 'uncontrollable';
 
 function drawerPanelPropType(props, propName, componentName) {
   const value = props[propName];
@@ -32,110 +26,105 @@ const StyledDrawer = styled.div`
   margin-bottom: 25px;
 `;
 
-class Drawer extends Component {
-  constructor(props) {
-    super(props);
+export const Drawer = props => {
+  const {
+    activeKeys,
+    children,
+    className,
+    closedIconName,
+    isAccordion,
+    onActiveKeysChanged,
+    openedIconName
+  } = props;
 
-    const currentActiveKeys = this.props.defaultActiveKeys;
-    this.state = {
-      activeKeys: toArray(currentActiveKeys)
-    };
-  }
+  const onItemClick = key => {
+    let nextActiveKeys = [...activeKeys];
 
-  componentWillReceiveProps(nextProps) {
-    if ('activeKeys' in nextProps) {
-      this.setState({
-        activeKeys: toArray(nextProps.activeKeys)
-      });
-    }
-  }
+    if (isAccordion) {
+      nextActiveKeys = nextActiveKeys[0] === key ? [] : [key];
+    } else {
+      const index = nextActiveKeys.indexOf(key);
+      const isOpen = index > -1;
 
-  onClickItem(key) {
-    return () => {
-      let activeKeys = [...this.state.activeKeys];
-
-      if (this.props.isAccordion) {
-        activeKeys = activeKeys[0] === key ? [] : [key];
+      if (isOpen) {
+        nextActiveKeys.splice(index, 1);
       } else {
-        const index = activeKeys.indexOf(key);
-        const isActive = index > -1;
-
-        if (isActive) {
-          activeKeys.splice(index, 1);
-        } else {
-          activeKeys.push(key);
-        }
+        nextActiveKeys.push(key);
       }
+    }
 
-      this.setState({ activeKeys });
-    };
-  }
+    onActiveKeysChanged(nextActiveKeys);
+  };
 
-  getPanels() {
-    const activeKeys = this.state.activeKeys;
-
-    return Children.map(this.props.children, (child, index) => {
+  const getPanels = () =>
+    Children.map(children, (child, index) => {
       // If there is no key provided, use the panel order as default key
-      const key = child.key || String(index);
+      const key = child.key || String(index + 1);
       const { title, titleAside } = child.props;
       const noPadding = child.props.noPadding || false;
 
-      let isActive = false;
-      if (this.props.isAccordion) {
-        isActive = activeKeys[0] === key;
+      let isOpen = false;
+      if (isAccordion) {
+        isOpen = activeKeys[0] === key;
       } else {
-        isActive = activeKeys.indexOf(key) > -1;
+        isOpen = activeKeys.indexOf(key) > -1;
       }
 
-      const props = {
+      const childProps = {
         key,
         title,
         titleAside,
         noPadding,
-        isActive,
+        isOpen,
         children: child.props.children,
-        onItemClick: this.onClickItem(key).bind(this),
-        closedIconName: this.props.closedIconName,
-        openedIconName: this.props.openedIconName
+        onItemClick: () => onItemClick(key),
+        closedIconName,
+        openedIconName
       };
 
-      return React.cloneElement(child, props);
+      return React.cloneElement(child, childProps);
     });
-  }
 
-  render() {
-    return (
-      <StyledDrawer className={this.props.className}>
-        {this.getPanels()}
-      </StyledDrawer>
-    );
-  }
-}
+  return <StyledDrawer className={className}>{getPanels()}</StyledDrawer>;
+};
 
 Drawer.propTypes = {
+  /** Set which panels are open */
+  activeKeys: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.arrayOf(PropTypes.string)
+  ]),
   /** Should only contain one or more Drawer.Panel elements */
   children: drawerPanelPropType,
   /** Add additional CSS classes to the root drawer element */
   className: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
   /** Override the default plus icon with another OE icon name */
   closedIconName: PropTypes.string,
-  /** Specify which panels are opened by default */
+  /** Used in uncontrolled mode to set initial drawer state */
   defaultActiveKeys: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.arrayOf(PropTypes.string)
   ]),
   /** Only allows one DrawerPanel to be open at a time */
   isAccordion: PropTypes.bool,
+  /** Function called when changing active keys */
+  onActiveKeysChanged: PropTypes.func,
   /** Override the default minus icon with another OE icon name */
   openedIconName: PropTypes.string
 };
 
 Drawer.defaultProps = {
+  activeKeys: [],
   isAccordion: false,
   closedIconName: 'plus',
+  onActiveKeysChanged: noop,
   openedIconName: 'minus'
 };
 
-Drawer.Panel = DrawerPanel;
+const UncontrolledDrawer = uncontrollable(Drawer, {
+  activeKeys: 'onActiveKeysChanged'
+});
 
-export default Drawer;
+UncontrolledDrawer.Panel = DrawerPanel;
+
+export default UncontrolledDrawer;

--- a/src/components/containers/drawer/Drawer.md
+++ b/src/components/containers/drawer/Drawer.md
@@ -1,8 +1,8 @@
-Use ``Drawer`` and ``Drawer.Panel`` components to wrap content in collapsable panels.
+Use `Drawer` and `Drawer.Panel` components to wrap content in collapsable panels. This component can be used in a controlled or uncontrolled way. When uncontrolled, you can specify `defaultActiveKeys` to set initial state. When controlled, you must supply both `activeKeys` and an `onActiveKeysChanged` handler.
 
-### Basic Example
+### Basic Example (Uncontrolled)
 ```
-<Drawer>
+<Drawer defaultActiveKeys={"1"}>
   <Drawer.Panel title="Panel 1">
     <p>Pretty much any content you want in here.</p>
   </Drawer.Panel>
@@ -19,8 +19,8 @@ Use ``Drawer`` and ``Drawer.Panel`` components to wrap content in collapsable pa
 ```
 
 
-### Accordion
-Add the ``isAccordion`` property to change the default behavior to an accordion
+### Accordion (Uncontrolled)
+Add the `isAccordion` property to change the default behavior to an accordion
 style, where only one panel can be opened at a time.
 ```
 <Drawer isAccordion>
@@ -43,28 +43,46 @@ style, where only one panel can be opened at a time.
 ```
 
 
-### Advanced Example
-Use the ``noPadding`` property to remove default padding within a panel (useful for lists and tables).
-Use the ``titleAside`` property to display text or other content on the right side of the panel header.
-You can customize the ``key`` property of each Panel; if not specified the default is a zero-based array.
+### Advanced Example (Controlled)
+Use the `noPadding` property to remove default padding within a panel (useful for lists and tables).
+Use the `titleAside` property to display text or other content on the right side of the panel header.
+You can customize the `key` property of each Panel; if not specified a default key value will be assigned
+matching the Panel's numeric position.
+
 Both the Drawer and Drawer.Panel components will accept additional classNames.
 
 ```
-<Drawer defaultActiveKeys={["first", "third"]} closedIconName="hand-right" openedIconName="hand-down" className="drawer-big">
-  <Drawer.Panel title="Panel 1" key="first" noPadding titleAside={<em>aside text</em>}>
-    <p>The default padding has been removed from this panel.</p>
-  </Drawer.Panel>
-  <Drawer.Panel title="Panel 2" key="second" noPadding titleAside={<Icon name='tag' />}>
-    <ul>
-      <li>List Item</li>
-      <li>Another Item</li>
-    </ul>
-  </Drawer.Panel>
-  <Drawer.Panel title="Panel 3" key="third" className="alt-color">
-    <div>
-      More content. Anim pariatur cliche reprehenderit, enim eiusmod
-      high life accusamus terry richardson ad squid.
-    </div>
-  </Drawer.Panel>
-</Drawer>
+class DrawerExample extends React.Component {
+  constructor() {
+    this.state = { activeKeys: ["second","3"] };
+    this.onActiveKeysChanged = this.onActiveKeysChanged.bind(this);
+  }
+
+  onActiveKeysChanged(value) {
+    this.setState({ activeKeys: value });
+  };
+
+  render() {
+    return (
+      <Drawer activeKeys={this.state.activeKeys} onActiveKeysChanged={this.onActiveKeysChanged} closedIconName="hand-right" openedIconName="hand-down" className="drawer-big">
+        <Drawer.Panel title="Panel One" key="first" noPadding titleAside={<em>aside text</em>}>
+          <p>The default padding has been removed from this panel.</p>
+        </Drawer.Panel>
+        <Drawer.Panel title="Panel Two" key="second" noPadding titleAside={<Icon name='tag' />}>
+          <ul>
+            <li>List Item</li>
+            <li>Another Item</li>
+          </ul>
+        </Drawer.Panel>
+        <Drawer.Panel title="Panel Three" className="alt-color">
+          <div>
+            More content. Anim pariatur cliche reprehenderit, enim eiusmod
+            high life accusamus terry richardson ad squid.
+          </div>
+        </Drawer.Panel>
+      </Drawer>
+    )
+  }
+}
+<DrawerExample />
 ```

--- a/src/components/containers/drawer/Drawer.specs.js
+++ b/src/components/containers/drawer/Drawer.specs.js
@@ -7,120 +7,103 @@ import Drawer from './Drawer';
 
 jest.mock('../../util/generateAlphaName', () => () => 'abcdef');
 
+const buildDrawer = props => (
+  <Drawer className="important" {...props}>
+    <Drawer.Panel
+      title="collapse 1"
+      key="1"
+      className="first"
+      titleAside="side text"
+    >
+      first
+    </Drawer.Panel>
+    <Drawer.Panel title="collapse 2" key="2" className="second" noPadding>
+      second
+    </Drawer.Panel>
+    <Drawer.Panel title="collapse 3" key="3" className="third">
+      third
+    </Drawer.Panel>
+  </Drawer>
+);
+
 describe('drawer component', () => {
   describe('drawer', () => {
-    let instanceToRender;
-
-    beforeEach(() => {
-      instanceToRender = (
-        <Drawer className="important">
-          <Drawer.Panel
-            title="collapse 1"
-            key="1"
-            className="first"
-            titleAside="side text"
-          >
-            first
-          </Drawer.Panel>
-          <Drawer.Panel title="collapse 2" key="2" className="second" noPadding>
-            second
-          </Drawer.Panel>
-          <Drawer.Panel title="collapse 3" key="3" className="third">
-            third
-          </Drawer.Panel>
-        </Drawer>
-      );
-    });
-
     it('renders as expected', () => {
-      const tree = renderer.create(instanceToRender).toJSON();
+      const tree = renderer.create(buildDrawer()).toJSON();
       expect(tree).toMatchSnapshot();
     });
 
-    it('click should toggle panel state', () => {
-      const drawerInstance = mount(instanceToRender);
+    it('clicking a closed panel should add panel key to activeKeys', () => {
+      const onActiveKeysChanged = jest.fn();
+      const drawerInstance = mount(buildDrawer({ onActiveKeysChanged }));
       const firstPanel = drawerInstance.find('.first');
       const panelButton = firstPanel.find('button');
 
       expect(panelButton.prop('aria-expanded')).toBe(false);
 
       panelButton.simulate('click');
+      expect(onActiveKeysChanged).toBeCalledWith(['1']);
+    });
+
+    it('clicking an open panel should remove panel key from activeKeys', () => {
+      const onActiveKeysChanged = jest.fn();
+      const drawerInstance = mount(
+        buildDrawer({ activeKeys: ['1'], onActiveKeysChanged })
+      );
+      const firstPanel = drawerInstance.find('.first');
+      const panelButton = firstPanel.find('button');
+
       expect(panelButton.prop('aria-expanded')).toBe(true);
 
       panelButton.simulate('click');
-      expect(panelButton.prop('aria-expanded')).toBe(false);
+      expect(onActiveKeysChanged).toBeCalledWith([]);
     });
 
-    it('should allow more than one drawer to be opened at a time', () => {
-      const drawerInstance = mount(instanceToRender);
+    it('should allow a second drawer to be opened', () => {
+      const onActiveKeysChanged = jest.fn();
+      const drawerInstance = mount(
+        buildDrawer({ activeKeys: ['1'], onActiveKeysChanged })
+      );
       const firstPanel = drawerInstance.find('.first');
       const firstButton = firstPanel.find('button');
       const thirdPanel = drawerInstance.find('.third');
       const thirdButton = thirdPanel.find('button');
 
-      expect(firstButton.prop('aria-expanded')).toBe(false);
-      expect(thirdButton.prop('aria-expanded')).toBe(false);
-
-      firstButton.simulate('click');
       expect(firstButton.prop('aria-expanded')).toBe(true);
       expect(thirdButton.prop('aria-expanded')).toBe(false);
 
       thirdButton.simulate('click');
-      expect(firstButton.prop('aria-expanded')).toBe(true);
-      expect(thirdButton.prop('aria-expanded')).toBe(true);
+      expect(onActiveKeysChanged).toBeCalledWith(['1', '3']);
     });
 
-    it('should set multiple default panels open at start', () => {
+    it('should allow rendering more than one active drawer', () => {
+      const onActiveKeysChanged = jest.fn();
       const drawerInstance = mount(
-        <Drawer defaultActiveKeys={['2', '3']}>
-          <Drawer.Panel title="collapse 1" key="1">first</Drawer.Panel>
-          <Drawer.Panel title="collapse 2" key="2">second</Drawer.Panel>
-          <Drawer.Panel title="collapse 3" key="3">third</Drawer.Panel>
-        </Drawer>
+        buildDrawer({ activeKeys: ['1', '3'], onActiveKeysChanged })
       );
+      const firstPanel = drawerInstance.find('.first');
+      const firstButton = firstPanel.find('button');
+      const thirdPanel = drawerInstance.find('.third');
+      const thirdButton = thirdPanel.find('button');
 
-      const panels = drawerInstance.find('[aria-expanded]');
-      expect(panels.at(0).prop('aria-expanded')).toBe(false);
-      expect(panels.at(1).prop('aria-expanded')).toBe(true);
-      expect(panels.at(2).prop('aria-expanded')).toBe(true);
+      expect(firstButton.prop('aria-expanded')).toBe(true);
+      expect(thirdButton.prop('aria-expanded')).toBe(true);
     });
   });
 
   describe('accordion', () => {
-    let instanceToRender;
-
-    beforeEach(() => {
-      instanceToRender = (
-        <Drawer isAccordion defaultActiveKeys="1">
-          <Drawer.Panel title="collapse 1" key="1" className="first">
-            first
-          </Drawer.Panel>
-          <Drawer.Panel title="collapse 2" key="2" className="second">
-            second
-          </Drawer.Panel>
-          <Drawer.Panel title="collapse 3" key="3" className="third">
-            third
-          </Drawer.Panel>
-        </Drawer>
-      );
-    });
+    const isAccordion = true;
 
     it('renders as expected', () => {
-      const tree = renderer.create(instanceToRender).toJSON();
+      const tree = renderer.create(buildDrawer({ isAccordion })).toJSON();
       expect(tree).toMatchSnapshot();
     });
 
-    it('default active key should set panel open', () => {
-      const accordionInstance = mount(instanceToRender);
-      const panels = accordionInstance.find('[aria-expanded]');
-
-      expect(panels.at(0).prop('aria-expanded')).toBe(true);
-      expect(panels.at(1).prop('aria-expanded')).toBe(false);
-      expect(panels.at(2).prop('aria-expanded')).toBe(false);
-    });
-
     it('should only allow one drawer to be opened at a time', () => {
-      const accordionInstance = mount(instanceToRender);
+      const onActiveKeysChanged = jest.fn();
+      const accordionInstance = mount(
+        buildDrawer({ isAccordion, onActiveKeysChanged, activeKeys: ['1'] })
+      );
       const firstPanel = accordionInstance.find('.first');
       const firstButton = firstPanel.find('button');
       const thirdPanel = accordionInstance.find('.third');
@@ -130,8 +113,7 @@ describe('drawer component', () => {
       expect(thirdButton.prop('aria-expanded')).toBe(false);
 
       thirdButton.simulate('click');
-      expect(firstButton.prop('aria-expanded')).toBe(false);
-      expect(thirdButton.prop('aria-expanded')).toBe(true);
+      expect(onActiveKeysChanged).toBeCalledWith(['3']);
     });
   });
 });

--- a/src/components/containers/drawer/DrawerPanel.js
+++ b/src/components/containers/drawer/DrawerPanel.js
@@ -6,9 +6,7 @@ import styled from 'styled-components';
 import genId from '../../util/generateAlphaName';
 import AnimateHeight from 'react-animate-height';
 
-const PanelWrapper = styled.div`
-  border-bottom: 1px solid ${colors.grayLight};
-`;
+const PanelWrapper = styled.div`border-bottom: 1px solid ${colors.grayLight};`;
 
 const PanelButton = styled.button`
   background: none;
@@ -27,7 +25,7 @@ const PanelButton = styled.button`
 `;
 
 const PanelIcon = styled(Icon)`
-  margin-right: .4em;
+  margin-right: 0.4em;
   position: relative;
   top: -1px;
 `;
@@ -49,7 +47,7 @@ const DrawerPanel = props => {
     children,
     className,
     closedIconName,
-    isActive,
+    isOpen,
     noPadding,
     onItemClick,
     openedIconName,
@@ -65,12 +63,12 @@ const DrawerPanel = props => {
     <PanelWrapper className={className}>
       <div id={headingAriaId} role="heading">
         <PanelButton
-          aria-expanded={isActive}
+          aria-expanded={isOpen}
           aria-controls={regionAriaId}
           onClick={() => onItemClick()}
         >
           <span>
-            <PanelIcon name={isActive ? openedIconName : closedIconName} />
+            <PanelIcon name={isOpen ? openedIconName : closedIconName} />
             {title}
           </span>
           {aside}
@@ -79,7 +77,7 @@ const DrawerPanel = props => {
       <PanelBody
         aria-labelledby={headingAriaId}
         duration={300}
-        height={isActive ? 'auto' : 0}
+        height={isOpen ? 'auto' : 0}
         id={regionAriaId}
         noPadding={noPadding}
         role="region"
@@ -94,6 +92,7 @@ DrawerPanel.propTypes = {
   children: PropTypes.any.isRequired,
   /** Add additional CSS classes to the drawer item element */
   className: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
+  /** @ignore */
   closedIconName: PropTypes.string,
   /** Title text displayed next to the open/close icon */
   title: PropTypes.oneOfType([
@@ -103,15 +102,18 @@ DrawerPanel.propTypes = {
   ]).isRequired,
   /** Aside text/content displayed on the right side of the panel title */
   titleAside: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
-  isActive: PropTypes.bool,
+  /** @ignore */
+  isOpen: PropTypes.bool,
   /** Removes the default padding from the panel body */
   noPadding: PropTypes.bool,
+  /** @ignore */
   onItemClick: PropTypes.func,
+  /** @ignore */
   openedIconName: PropTypes.string
 };
 
 DrawerPanel.defaultProps = {
-  isActive: false,
+  isOpen: false,
   noPadding: false
 };
 

--- a/src/components/containers/drawer/DrawerPanel.md
+++ b/src/components/containers/drawer/DrawerPanel.md
@@ -1,0 +1,1 @@
+The `DrawerPanel` component is used within the Drawer component.

--- a/src/components/containers/drawer/__snapshots__/Drawer.specs.js.snap
+++ b/src/components/containers/drawer/__snapshots__/Drawer.specs.js.snap
@@ -2,55 +2,10 @@
 
 exports[`drawer component accordion renders as expected 1`] = `
 <div
-  className="sc-EHOje ktKLsF"
+  className="important sc-EHOje ktKLsF"
 >
   <div
-    className="first sc-bwzfXH dYpfLQ"
-  >
-    <div
-      id="abcdef"
-      role="heading"
-    >
-      <button
-        aria-controls="abcdef"
-        aria-expanded={true}
-        className="sc-htpNat ebhkUu"
-        onClick={[Function]}
-      >
-        <span>
-          <i
-            aria-hidden={true}
-            className="sc-bxivhb beQLQJ sc-bdVaJa dRgmsV"
-            content="63d"
-            fontFamily="oecom-icons"
-            fontSize="inherit"
-          />
-          collapse 1
-        </span>
-      </button>
-    </div>
-    <div
-      aria-hidden={false}
-      aria-labelledby="abcdef"
-      className="rah-static rah-static--height-auto sc-ifAKCX gUdFEl"
-      id="abcdef"
-      role="region"
-      style={
-        Object {
-          "height": "auto",
-          "overflow": "visible",
-        }
-      }
-    >
-      <div
-        className={undefined}
-      >
-        first
-      </div>
-    </div>
-  </div>
-  <div
-    className="second sc-bwzfXH dYpfLQ"
+    className="first sc-bwzfXH fsHaqT"
   >
     <div
       id="abcdef"
@@ -65,13 +20,16 @@ exports[`drawer component accordion renders as expected 1`] = `
         <span>
           <i
             aria-hidden={true}
-            className="sc-bxivhb beQLQJ sc-bdVaJa iOqSxE"
+            className="sc-bxivhb UZmtw sc-bdVaJa iOqSxE"
             content="63f"
             fontFamily="oecom-icons"
             fontSize="inherit"
           />
-          collapse 2
+          collapse 1
         </span>
+        <aside>
+          side text
+        </aside>
       </button>
     </div>
     <div
@@ -90,12 +48,12 @@ exports[`drawer component accordion renders as expected 1`] = `
       <div
         className={undefined}
       >
-        second
+        first
       </div>
     </div>
   </div>
   <div
-    className="third sc-bwzfXH dYpfLQ"
+    className="second sc-bwzfXH fsHaqT"
   >
     <div
       id="abcdef"
@@ -110,7 +68,52 @@ exports[`drawer component accordion renders as expected 1`] = `
         <span>
           <i
             aria-hidden={true}
-            className="sc-bxivhb beQLQJ sc-bdVaJa iOqSxE"
+            className="sc-bxivhb UZmtw sc-bdVaJa iOqSxE"
+            content="63f"
+            fontFamily="oecom-icons"
+            fontSize="inherit"
+          />
+          collapse 2
+        </span>
+      </button>
+    </div>
+    <div
+      aria-hidden={true}
+      aria-labelledby="abcdef"
+      className="rah-static rah-static--height-zero sc-ifAKCX lnWkgR"
+      id="abcdef"
+      role="region"
+      style={
+        Object {
+          "height": 0,
+          "overflow": "hidden",
+        }
+      }
+    >
+      <div
+        className={undefined}
+      >
+        second
+      </div>
+    </div>
+  </div>
+  <div
+    className="third sc-bwzfXH fsHaqT"
+  >
+    <div
+      id="abcdef"
+      role="heading"
+    >
+      <button
+        aria-controls="abcdef"
+        aria-expanded={false}
+        className="sc-htpNat ebhkUu"
+        onClick={[Function]}
+      >
+        <span>
+          <i
+            aria-hidden={true}
+            className="sc-bxivhb UZmtw sc-bdVaJa iOqSxE"
             content="63f"
             fontFamily="oecom-icons"
             fontSize="inherit"
@@ -147,7 +150,7 @@ exports[`drawer component drawer renders as expected 1`] = `
   className="important sc-EHOje ktKLsF"
 >
   <div
-    className="first sc-bwzfXH dYpfLQ"
+    className="first sc-bwzfXH fsHaqT"
   >
     <div
       id="abcdef"
@@ -162,7 +165,7 @@ exports[`drawer component drawer renders as expected 1`] = `
         <span>
           <i
             aria-hidden={true}
-            className="sc-bxivhb beQLQJ sc-bdVaJa iOqSxE"
+            className="sc-bxivhb UZmtw sc-bdVaJa iOqSxE"
             content="63f"
             fontFamily="oecom-icons"
             fontSize="inherit"
@@ -195,7 +198,7 @@ exports[`drawer component drawer renders as expected 1`] = `
     </div>
   </div>
   <div
-    className="second sc-bwzfXH dYpfLQ"
+    className="second sc-bwzfXH fsHaqT"
   >
     <div
       id="abcdef"
@@ -210,7 +213,7 @@ exports[`drawer component drawer renders as expected 1`] = `
         <span>
           <i
             aria-hidden={true}
-            className="sc-bxivhb beQLQJ sc-bdVaJa iOqSxE"
+            className="sc-bxivhb UZmtw sc-bdVaJa iOqSxE"
             content="63f"
             fontFamily="oecom-icons"
             fontSize="inherit"
@@ -240,7 +243,7 @@ exports[`drawer component drawer renders as expected 1`] = `
     </div>
   </div>
   <div
-    className="third sc-bwzfXH dYpfLQ"
+    className="third sc-bwzfXH fsHaqT"
   >
     <div
       id="abcdef"
@@ -255,7 +258,7 @@ exports[`drawer component drawer renders as expected 1`] = `
         <span>
           <i
             aria-hidden={true}
-            className="sc-bxivhb beQLQJ sc-bdVaJa iOqSxE"
+            className="sc-bxivhb UZmtw sc-bdVaJa iOqSxE"
             content="63f"
             fontFamily="oecom-icons"
             fontSize="inherit"


### PR DESCRIPTION
Drawer Component:
1. Added onActiveKeysChanged callback, removed defaultActiveKeys prop
2. Converted Drawer from class to function, removed state
3. Renamed Drawer prop isActive -> isOpen
4. Wrapped as uncontrollable component, now works controlled or uncontrolled
5. Updated docs to include both controlled and uncontrolled examples